### PR TITLE
Chore/snapshotter state cache

### DIFF
--- a/pkgs/contract/abi.json
+++ b/pkgs/contract/abi.json
@@ -6,22 +6,22 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "address",
-                "name": "target",
-                "type": "address"
-            }
+        {
+            "internalType": "address",
+            "name": "target",
+            "type": "address"
+        }
         ],
         "name": "AddressEmptyCode",
         "type": "error"
     },
     {
         "inputs": [
-            {
-                "internalType": "address",
-                "name": "implementation",
-                "type": "address"
-            }
+        {
+            "internalType": "address",
+            "name": "implementation",
+            "type": "address"
+        }
         ],
         "name": "ERC1967InvalidImplementation",
         "type": "error"
@@ -33,7 +33,7 @@
     },
     {
         "inputs": [],
-        "name": "FailedInnerCall",
+        "name": "FailedCall",
         "type": "error"
     },
     {
@@ -48,22 +48,22 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "address",
-                "name": "owner",
-                "type": "address"
-            }
+        {
+            "internalType": "address",
+            "name": "owner",
+            "type": "address"
+        }
         ],
         "name": "OwnableInvalidOwner",
         "type": "error"
     },
     {
         "inputs": [
-            {
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            }
+        {
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+        }
         ],
         "name": "OwnableUnauthorizedAccount",
         "type": "error"
@@ -75,11 +75,11 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "bytes32",
-                "name": "slot",
-                "type": "bytes32"
-            }
+        {
+            "internalType": "bytes32",
+            "name": "slot",
+            "type": "bytes32"
+        }
         ],
         "name": "UUPSUnsupportedProxiableUUID",
         "type": "error"
@@ -87,24 +87,24 @@
     {
         "anonymous": false,
         "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "dataMarketAddress",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "address",
-                "name": "adminAddress",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "bool",
-                "name": "allowed",
-                "type": "bool"
-            }
+        {
+            "indexed": true,
+            "internalType": "address",
+            "name": "dataMarketAddress",
+            "type": "address"
+        },
+        {
+            "indexed": false,
+            "internalType": "address",
+            "name": "adminAddress",
+            "type": "address"
+        },
+        {
+            "indexed": false,
+            "internalType": "bool",
+            "name": "allowed",
+            "type": "bool"
+        }
         ],
         "name": "AdminsUpdated",
         "type": "event"
@@ -112,24 +112,24 @@
     {
         "anonymous": false,
         "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "dataMarketAddress",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "uint256",
-                "name": "epochId",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "timestamp",
-                "type": "uint256"
-            }
+        {
+            "indexed": true,
+            "internalType": "address",
+            "name": "dataMarketAddress",
+            "type": "address"
+        },
+        {
+            "indexed": true,
+            "internalType": "uint256",
+            "name": "epochId",
+            "type": "uint256"
+        },
+        {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "timestamp",
+            "type": "uint256"
+        }
         ],
         "name": "BatchSubmissionsCompleted",
         "type": "event"
@@ -137,42 +137,36 @@
     {
         "anonymous": false,
         "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "dataMarketAddress",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "address",
-                "name": "snapshotterAddress",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "slotId",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "dayId",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "rewardPoints",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "timestamp",
-                "type": "uint256"
-            }
+        {
+            "indexed": true,
+            "internalType": "address",
+            "name": "dataMarketAddress",
+            "type": "address"
+        },
+        {
+            "indexed": false,
+            "internalType": "address",
+            "name": "snapshotterAddress",
+            "type": "address"
+        },
+        {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "slotId",
+            "type": "uint256"
+        },
+        {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "dayId",
+            "type": "uint256"
+        },
+        {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "timestamp",
+            "type": "uint256"
+        }
         ],
         "name": "DailyTaskCompletedEvent",
         "type": "event"
@@ -180,48 +174,48 @@
     {
         "anonymous": false,
         "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "ownerAddress",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint8",
-                "name": "epochSize",
-                "type": "uint8"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "sourceChainId",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "sourceChainBlockTime",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "internalType": "bool",
-                "name": "useBlockNumberAsEpochId",
-                "type": "bool"
-            },
-            {
-                "indexed": false,
-                "internalType": "address",
-                "name": "protocolState",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "address",
-                "name": "dataMarketAddress",
-                "type": "address"
-            }
+        {
+            "indexed": true,
+            "internalType": "address",
+            "name": "ownerAddress",
+            "type": "address"
+        },
+        {
+            "indexed": false,
+            "internalType": "uint8",
+            "name": "epochSize",
+            "type": "uint8"
+        },
+        {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "sourceChainId",
+            "type": "uint256"
+        },
+        {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "sourceChainBlockTime",
+            "type": "uint256"
+        },
+        {
+            "indexed": false,
+            "internalType": "bool",
+            "name": "useBlockNumberAsEpochId",
+            "type": "bool"
+        },
+        {
+            "indexed": false,
+            "internalType": "address",
+            "name": "protocolState",
+            "type": "address"
+        },
+        {
+            "indexed": false,
+            "internalType": "address",
+            "name": "dataMarketAddress",
+            "type": "address"
+        }
         ],
         "name": "DataMarketCreated",
         "type": "event"
@@ -229,24 +223,24 @@
     {
         "anonymous": false,
         "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "dataMarketAddress",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "dayId",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "timestamp",
-                "type": "uint256"
-            }
+        {
+            "indexed": true,
+            "internalType": "address",
+            "name": "dataMarketAddress",
+            "type": "address"
+        },
+        {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "dayId",
+            "type": "uint256"
+        },
+        {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "timestamp",
+            "type": "uint256"
+        }
         ],
         "name": "DayStartedEvent",
         "type": "event"
@@ -254,36 +248,36 @@
     {
         "anonymous": false,
         "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "dataMarketAddress",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "string",
-                "name": "batchCid",
-                "type": "string"
-            },
-            {
-                "indexed": true,
-                "internalType": "uint256",
-                "name": "epochId",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "timestamp",
-                "type": "uint256"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "validatorAddr",
-                "type": "address"
-            }
+        {
+            "indexed": true,
+            "internalType": "address",
+            "name": "dataMarketAddress",
+            "type": "address"
+        },
+        {
+            "indexed": false,
+            "internalType": "string",
+            "name": "batchCid",
+            "type": "string"
+        },
+        {
+            "indexed": true,
+            "internalType": "uint256",
+            "name": "epochId",
+            "type": "uint256"
+        },
+        {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "timestamp",
+            "type": "uint256"
+        },
+        {
+            "indexed": true,
+            "internalType": "address",
+            "name": "validatorAddr",
+            "type": "address"
+        }
         ],
         "name": "DelayedAttestationSubmitted",
         "type": "event"
@@ -291,30 +285,30 @@
     {
         "anonymous": false,
         "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "dataMarketAddress",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "string",
-                "name": "batchCid",
-                "type": "string"
-            },
-            {
-                "indexed": true,
-                "internalType": "uint256",
-                "name": "epochId",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "timestamp",
-                "type": "uint256"
-            }
+        {
+            "indexed": true,
+            "internalType": "address",
+            "name": "dataMarketAddress",
+            "type": "address"
+        },
+        {
+            "indexed": false,
+            "internalType": "string",
+            "name": "batchCid",
+            "type": "string"
+        },
+        {
+            "indexed": true,
+            "internalType": "uint256",
+            "name": "epochId",
+            "type": "uint256"
+        },
+        {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "timestamp",
+            "type": "uint256"
+        }
         ],
         "name": "DelayedBatchSubmitted",
         "type": "event"
@@ -322,48 +316,48 @@
     {
         "anonymous": false,
         "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "dataMarketAddress",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "snapshotterAddr",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "slotId",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "internalType": "string",
-                "name": "snapshotCid",
-                "type": "string"
-            },
-            {
-                "indexed": true,
-                "internalType": "uint256",
-                "name": "epochId",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "internalType": "string",
-                "name": "projectId",
-                "type": "string"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "timestamp",
-                "type": "uint256"
-            }
+        {
+            "indexed": true,
+            "internalType": "address",
+            "name": "dataMarketAddress",
+            "type": "address"
+        },
+        {
+            "indexed": true,
+            "internalType": "address",
+            "name": "snapshotterAddr",
+            "type": "address"
+        },
+        {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "slotId",
+            "type": "uint256"
+        },
+        {
+            "indexed": false,
+            "internalType": "string",
+            "name": "snapshotCid",
+            "type": "string"
+        },
+        {
+            "indexed": true,
+            "internalType": "uint256",
+            "name": "epochId",
+            "type": "uint256"
+        },
+        {
+            "indexed": false,
+            "internalType": "string",
+            "name": "projectId",
+            "type": "string"
+        },
+        {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "timestamp",
+            "type": "uint256"
+        }
         ],
         "name": "DelayedSnapshotSubmitted",
         "type": "event"
@@ -371,18 +365,18 @@
     {
         "anonymous": false,
         "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "owner",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            }
+        {
+            "indexed": true,
+            "internalType": "address",
+            "name": "owner",
+            "type": "address"
+        },
+        {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+        }
         ],
         "name": "EmergencyWithdraw",
         "type": "event"
@@ -390,36 +384,36 @@
     {
         "anonymous": false,
         "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "dataMarketAddress",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "uint256",
-                "name": "epochId",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "begin",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "end",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "timestamp",
-                "type": "uint256"
-            }
+        {
+            "indexed": true,
+            "internalType": "address",
+            "name": "dataMarketAddress",
+            "type": "address"
+        },
+        {
+            "indexed": true,
+            "internalType": "uint256",
+            "name": "epochId",
+            "type": "uint256"
+        },
+        {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "begin",
+            "type": "uint256"
+        },
+        {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "end",
+            "type": "uint256"
+        },
+        {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "timestamp",
+            "type": "uint256"
+        }
         ],
         "name": "EpochReleased",
         "type": "event"
@@ -427,12 +421,12 @@
     {
         "anonymous": false,
         "inputs": [
-            {
-                "indexed": false,
-                "internalType": "uint64",
-                "name": "version",
-                "type": "uint64"
-            }
+        {
+            "indexed": false,
+            "internalType": "uint64",
+            "name": "version",
+            "type": "uint64"
+        }
         ],
         "name": "Initialized",
         "type": "event"
@@ -440,18 +434,37 @@
     {
         "anonymous": false,
         "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "previousOwner",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "newOwner",
-                "type": "address"
-            }
+        {
+            "indexed": true,
+            "internalType": "address",
+            "name": "previousOwner",
+            "type": "address"
+        },
+        {
+            "indexed": true,
+            "internalType": "address",
+            "name": "newOwner",
+            "type": "address"
+        }
+        ],
+        "name": "OwnershipTransferStarted",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+        {
+            "indexed": true,
+            "internalType": "address",
+            "name": "previousOwner",
+            "type": "address"
+        },
+        {
+            "indexed": true,
+            "internalType": "address",
+            "name": "newOwner",
+            "type": "address"
+        }
         ],
         "name": "OwnershipTransferred",
         "type": "event"
@@ -459,24 +472,24 @@
     {
         "anonymous": false,
         "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "user",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "timestamp",
-                "type": "uint256"
-            }
+        {
+            "indexed": true,
+            "internalType": "address",
+            "name": "user",
+            "type": "address"
+        },
+        {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+        },
+        {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "timestamp",
+            "type": "uint256"
+        }
         ],
         "name": "RewardsClaimed",
         "type": "event"
@@ -484,24 +497,67 @@
     {
         "anonymous": false,
         "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "dataMarketAddress",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "address",
-                "name": "sequencerAddress",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "bool",
-                "name": "allowed",
-                "type": "bool"
-            }
+        {
+            "indexed": true,
+            "internalType": "address",
+            "name": "dataMarketAddress",
+            "type": "address"
+        },
+        {
+            "indexed": false,
+            "internalType": "address",
+            "name": "snapshotterAddress",
+            "type": "address"
+        },
+        {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "slotId",
+            "type": "uint256"
+        },
+        {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "dayId",
+            "type": "uint256"
+        },
+        {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "rewardPoints",
+            "type": "uint256"
+        },
+        {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "timestamp",
+            "type": "uint256"
+        }
+        ],
+        "name": "RewardsDistributedEvent",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+        {
+            "indexed": true,
+            "internalType": "address",
+            "name": "dataMarketAddress",
+            "type": "address"
+        },
+        {
+            "indexed": false,
+            "internalType": "address",
+            "name": "sequencerAddress",
+            "type": "address"
+        },
+        {
+            "indexed": false,
+            "internalType": "bool",
+            "name": "allowed",
+            "type": "bool"
+        }
         ],
         "name": "SequencersUpdated",
         "type": "event"
@@ -509,36 +565,36 @@
     {
         "anonymous": false,
         "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "dataMarketAddress",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "string",
-                "name": "batchCid",
-                "type": "string"
-            },
-            {
-                "indexed": true,
-                "internalType": "uint256",
-                "name": "epochId",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "timestamp",
-                "type": "uint256"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "validatorAddr",
-                "type": "address"
-            }
+        {
+            "indexed": true,
+            "internalType": "address",
+            "name": "dataMarketAddress",
+            "type": "address"
+        },
+        {
+            "indexed": false,
+            "internalType": "string",
+            "name": "batchCid",
+            "type": "string"
+        },
+        {
+            "indexed": true,
+            "internalType": "uint256",
+            "name": "epochId",
+            "type": "uint256"
+        },
+        {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "timestamp",
+            "type": "uint256"
+        },
+        {
+            "indexed": true,
+            "internalType": "address",
+            "name": "validatorAddr",
+            "type": "address"
+        }
         ],
         "name": "SnapshotBatchAttestationSubmitted",
         "type": "event"
@@ -546,30 +602,30 @@
     {
         "anonymous": false,
         "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "dataMarketAddress",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "uint256",
-                "name": "epochId",
-                "type": "uint256"
-            },
-            {
-                "indexed": true,
-                "internalType": "string",
-                "name": "batchCid",
-                "type": "string"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "timestamp",
-                "type": "uint256"
-            }
+        {
+            "indexed": true,
+            "internalType": "address",
+            "name": "dataMarketAddress",
+            "type": "address"
+        },
+        {
+            "indexed": true,
+            "internalType": "uint256",
+            "name": "epochId",
+            "type": "uint256"
+        },
+        {
+            "indexed": true,
+            "internalType": "string",
+            "name": "batchCid",
+            "type": "string"
+        },
+        {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "timestamp",
+            "type": "uint256"
+        }
         ],
         "name": "SnapshotBatchFinalized",
         "type": "event"
@@ -577,30 +633,30 @@
     {
         "anonymous": false,
         "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "dataMarketAddress",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "string",
-                "name": "batchCid",
-                "type": "string"
-            },
-            {
-                "indexed": true,
-                "internalType": "uint256",
-                "name": "epochId",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "timestamp",
-                "type": "uint256"
-            }
+        {
+            "indexed": true,
+            "internalType": "address",
+            "name": "dataMarketAddress",
+            "type": "address"
+        },
+        {
+            "indexed": false,
+            "internalType": "string",
+            "name": "batchCid",
+            "type": "string"
+        },
+        {
+            "indexed": true,
+            "internalType": "uint256",
+            "name": "epochId",
+            "type": "uint256"
+        },
+        {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "timestamp",
+            "type": "uint256"
+        }
         ],
         "name": "SnapshotBatchSubmitted",
         "type": "event"
@@ -608,42 +664,42 @@
     {
         "anonymous": false,
         "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "dataMarketAddress",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "uint256",
-                "name": "epochId",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "epochEnd",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "internalType": "string",
-                "name": "projectId",
-                "type": "string"
-            },
-            {
-                "indexed": false,
-                "internalType": "string",
-                "name": "snapshotCid",
-                "type": "string"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "timestamp",
-                "type": "uint256"
-            }
+        {
+            "indexed": true,
+            "internalType": "address",
+            "name": "dataMarketAddress",
+            "type": "address"
+        },
+        {
+            "indexed": true,
+            "internalType": "uint256",
+            "name": "epochId",
+            "type": "uint256"
+        },
+        {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "epochEnd",
+            "type": "uint256"
+        },
+        {
+            "indexed": false,
+            "internalType": "string",
+            "name": "projectId",
+            "type": "string"
+        },
+        {
+            "indexed": false,
+            "internalType": "string",
+            "name": "snapshotCid",
+            "type": "string"
+        },
+        {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "timestamp",
+            "type": "uint256"
+        }
         ],
         "name": "SnapshotFinalized",
         "type": "event"
@@ -651,30 +707,30 @@
     {
         "anonymous": false,
         "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "dataMarketAddress",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "uint256",
-                "name": "epochId",
-                "type": "uint256"
-            },
-            {
-                "indexed": true,
-                "internalType": "string",
-                "name": "batchCid",
-                "type": "string"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "timestamp",
-                "type": "uint256"
-            }
+        {
+            "indexed": true,
+            "internalType": "address",
+            "name": "dataMarketAddress",
+            "type": "address"
+        },
+        {
+            "indexed": true,
+            "internalType": "uint256",
+            "name": "epochId",
+            "type": "uint256"
+        },
+        {
+            "indexed": true,
+            "internalType": "string",
+            "name": "batchCid",
+            "type": "string"
+        },
+        {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "timestamp",
+            "type": "uint256"
+        }
         ],
         "name": "TriggerBatchResubmission",
         "type": "event"
@@ -682,12 +738,12 @@
     {
         "anonymous": false,
         "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "implementation",
-                "type": "address"
-            }
+        {
+            "indexed": true,
+            "internalType": "address",
+            "name": "implementation",
+            "type": "address"
+        }
         ],
         "name": "Upgraded",
         "type": "event"
@@ -695,36 +751,36 @@
     {
         "anonymous": false,
         "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "dataMarketAddress",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "uint256",
-                "name": "epochId",
-                "type": "uint256"
-            },
-            {
-                "indexed": true,
-                "internalType": "string",
-                "name": "batchCid",
-                "type": "string"
-            },
-            {
-                "indexed": false,
-                "internalType": "address",
-                "name": "validator",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "timestamp",
-                "type": "uint256"
-            }
+        {
+            "indexed": true,
+            "internalType": "address",
+            "name": "dataMarketAddress",
+            "type": "address"
+        },
+        {
+            "indexed": true,
+            "internalType": "uint256",
+            "name": "epochId",
+            "type": "uint256"
+        },
+        {
+            "indexed": true,
+            "internalType": "string",
+            "name": "batchCid",
+            "type": "string"
+        },
+        {
+            "indexed": false,
+            "internalType": "address",
+            "name": "validator",
+            "type": "address"
+        },
+        {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "timestamp",
+            "type": "uint256"
+        }
         ],
         "name": "ValidatorAttestationsInvalidated",
         "type": "event"
@@ -732,100 +788,100 @@
     {
         "anonymous": false,
         "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "dataMarketAddress",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "address",
-                "name": "validatorAddress",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "bool",
-                "name": "allowed",
-                "type": "bool"
-            }
+        {
+            "indexed": true,
+            "internalType": "address",
+            "name": "dataMarketAddress",
+            "type": "address"
+        },
+        {
+            "indexed": false,
+            "internalType": "address",
+            "name": "validatorAddress",
+            "type": "address"
+        },
+        {
+            "indexed": false,
+            "internalType": "bool",
+            "name": "allowed",
+            "type": "bool"
+        }
         ],
         "name": "ValidatorsUpdated",
         "type": "event"
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        }
         ],
         "name": "DAY_SIZE",
         "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        }
         ],
         "name": "EPOCH_SIZE",
         "outputs": [
-            {
-                "internalType": "uint8",
-                "name": "",
-                "type": "uint8"
-            }
+        {
+            "internalType": "uint8",
+            "name": "",
+            "type": "uint8"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        }
         ],
         "name": "SOURCE_CHAIN_BLOCK_TIME",
         "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        }
         ],
         "name": "SOURCE_CHAIN_ID",
         "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
@@ -834,315 +890,322 @@
         "inputs": [],
         "name": "UPGRADE_INTERFACE_VERSION",
         "outputs": [
-            {
-                "internalType": "string",
-                "name": "",
-                "type": "string"
-            }
+        {
+            "internalType": "string",
+            "name": "",
+            "type": "string"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        }
         ],
         "name": "USE_BLOCK_NUMBER_AS_EPOCH_ID",
         "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
+        {
+            "internalType": "bool",
+            "name": "",
+            "type": "bool"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
+        "inputs": [],
+        "name": "acceptOwnership",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
         "inputs": [
-            {
-                "internalType": "address",
-                "name": "addr",
-                "type": "address"
-            }
+        {
+            "internalType": "address",
+            "name": "addr",
+            "type": "address"
+        }
         ],
         "name": "allSnapshotters",
         "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
+        {
+            "internalType": "bool",
+            "name": "",
+            "type": "bool"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        }
         ],
         "name": "attestationSubmissionWindow",
         "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            },
-            {
-                "internalType": "string",
-                "name": "batchCid",
-                "type": "string"
-            },
-            {
-                "internalType": "address",
-                "name": "validator",
-                "type": "address"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        },
+        {
+            "internalType": "string",
+            "name": "batchCid",
+            "type": "string"
+        },
+        {
+            "internalType": "address",
+            "name": "validator",
+            "type": "address"
+        }
         ],
         "name": "attestationsReceived",
         "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
+        {
+            "internalType": "bool",
+            "name": "",
+            "type": "bool"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            },
-            {
-                "internalType": "string",
-                "name": "batchCid",
-                "type": "string"
-            },
-            {
-                "internalType": "bytes32",
-                "name": "finalizedCidsRootHash",
-                "type": "bytes32"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        },
+        {
+            "internalType": "string",
+            "name": "batchCid",
+            "type": "string"
+        },
+        {
+            "internalType": "bytes32",
+            "name": "finalizedCidsRootHash",
+            "type": "bytes32"
+        }
         ],
         "name": "attestationsReceivedCount",
         "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            },
-            {
-                "internalType": "string",
-                "name": "batchCid",
-                "type": "string"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        },
+        {
+            "internalType": "string",
+            "name": "batchCid",
+            "type": "string"
+        }
         ],
         "name": "batchCidAttestationStatus",
         "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
+        {
+            "internalType": "bool",
+            "name": "",
+            "type": "bool"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            },
-            {
-                "internalType": "string",
-                "name": "batchCid",
-                "type": "string"
-            },
-            {
-                "internalType": "uint256",
-                "name": "idx",
-                "type": "uint256"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        },
+        {
+            "internalType": "string",
+            "name": "batchCid",
+            "type": "string"
+        },
+        {
+            "internalType": "uint256",
+            "name": "idx",
+            "type": "uint256"
+        }
         ],
         "name": "batchCidDivergentValidators",
         "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
+        {
+            "internalType": "address",
+            "name": "",
+            "type": "address"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            },
-            {
-                "internalType": "string",
-                "name": "batchCid",
-                "type": "string"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        },
+        {
+            "internalType": "string",
+            "name": "batchCid",
+            "type": "string"
+        }
         ],
         "name": "batchCidSequencerAttestation",
         "outputs": [
-            {
-                "internalType": "bytes32",
-                "name": "",
-                "type": "bytes32"
-            }
+        {
+            "internalType": "bytes32",
+            "name": "",
+            "type": "bytes32"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            },
-            {
-                "internalType": "string",
-                "name": "batchCid",
-                "type": "string"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        },
+        {
+            "internalType": "string",
+            "name": "batchCid",
+            "type": "string"
+        }
         ],
         "name": "batchCidToProjects",
         "outputs": [
-            {
-                "internalType": "string[]",
-                "name": "",
-                "type": "string[]"
-            }
+        {
+            "internalType": "string[]",
+            "name": "",
+            "type": "string[]"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        }
         ],
         "name": "batchSubmissionWindow",
         "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            },
-            {
-                "internalType": "string",
-                "name": "batchCid",
-                "type": "string"
-            },
-            {
-                "internalType": "uint256",
-                "name": "epochId",
-                "type": "uint256"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        },
+        {
+            "internalType": "string",
+            "name": "batchCid",
+            "type": "string"
+        },
+        {
+            "internalType": "uint256",
+            "name": "epochId",
+            "type": "uint256"
+        }
         ],
         "name": "checkDynamicConsensusAttestations",
         "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
+        {
+            "internalType": "bool",
+            "name": "",
+            "type": "bool"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "slotId",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "day",
-                "type": "uint256"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        },
+        {
+            "internalType": "uint256",
+            "name": "slotId",
+            "type": "uint256"
+        },
+        {
+            "internalType": "uint256",
+            "name": "day",
+            "type": "uint256"
+        }
         ],
         "name": "checkSlotTaskStatusForDay",
         "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
+        {
+            "internalType": "bool",
+            "name": "",
+            "type": "bool"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "address",
-                "name": "_user",
-                "type": "address"
-            }
+        {
+            "internalType": "address",
+            "name": "_user",
+            "type": "address"
+        }
         ],
         "name": "claimRewards",
         "outputs": [],
@@ -1151,87 +1214,87 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "address",
-                "name": "ownerAddress",
-                "type": "address"
-            },
-            {
-                "internalType": "uint8",
-                "name": "epochSize",
-                "type": "uint8"
-            },
-            {
-                "internalType": "uint256",
-                "name": "sourceChainId",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "sourceChainBlockTime",
-                "type": "uint256"
-            },
-            {
-                "internalType": "bool",
-                "name": "useBlockNumberAsEpochId",
-                "type": "bool"
-            }
+        {
+            "internalType": "address",
+            "name": "ownerAddress",
+            "type": "address"
+        },
+        {
+            "internalType": "uint8",
+            "name": "epochSize",
+            "type": "uint8"
+        },
+        {
+            "internalType": "uint256",
+            "name": "sourceChainId",
+            "type": "uint256"
+        },
+        {
+            "internalType": "uint256",
+            "name": "sourceChainBlockTime",
+            "type": "uint256"
+        },
+        {
+            "internalType": "bool",
+            "name": "useBlockNumberAsEpochId",
+            "type": "bool"
+        }
         ],
         "name": "createDataMarket",
         "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
+        {
+            "internalType": "address",
+            "name": "",
+            "type": "address"
+        }
         ],
         "stateMutability": "nonpayable",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        }
         ],
         "name": "currentEpoch",
         "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "begin",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "end",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "epochId",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "begin",
+            "type": "uint256"
+        },
+        {
+            "internalType": "uint256",
+            "name": "end",
+            "type": "uint256"
+        },
+        {
+            "internalType": "uint256",
+            "name": "epochId",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        }
         ],
         "name": "dailySnapshotQuota",
         "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
@@ -1240,30 +1303,30 @@
         "inputs": [],
         "name": "dataMarketCount",
         "outputs": [
-            {
-                "internalType": "uint8",
-                "name": "",
-                "type": "uint8"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "address",
-                "name": "dataMarketAddress",
-                "type": "address"
-            }
+        {
+            "internalType": "address",
+            "name": "dataMarketAddress",
+            "type": "address"
+        }
         ],
         "name": "dataMarketEnabled",
         "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
+        {
+            "internalType": "bool",
+            "name": "",
+            "type": "bool"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
@@ -1272,122 +1335,122 @@
         "inputs": [],
         "name": "dataMarketFactory",
         "outputs": [
-            {
-                "internalType": "contract DataMarketFactory",
-                "name": "",
-                "type": "address"
-            }
+        {
+            "internalType": "contract DataMarketFactory",
+            "name": "",
+            "type": "address"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "uint8",
-                "name": "dataMarketId",
-                "type": "uint8"
-            }
+        {
+            "internalType": "uint256",
+            "name": "dataMarketId",
+            "type": "uint256"
+        }
         ],
         "name": "dataMarketIdToAddress",
         "outputs": [
-            {
-                "internalType": "address",
-                "name": "dataMarketAddress",
-                "type": "address"
-            }
+        {
+            "internalType": "address",
+            "name": "dataMarketAddress",
+            "type": "address"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
+        {
+            "internalType": "address",
+            "name": "",
+            "type": "address"
+        }
         ],
         "name": "dataMarkets",
         "outputs": [
-            {
-                "internalType": "address",
-                "name": "ownerAddress",
-                "type": "address"
-            },
-            {
-                "internalType": "uint8",
-                "name": "epochSize",
-                "type": "uint8"
-            },
-            {
-                "internalType": "uint256",
-                "name": "sourceChainId",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "sourceChainBlockTime",
-                "type": "uint256"
-            },
-            {
-                "internalType": "bool",
-                "name": "useBlockNumberAsEpochId",
-                "type": "bool"
-            },
-            {
-                "internalType": "bool",
-                "name": "enabled",
-                "type": "bool"
-            },
-            {
-                "internalType": "address",
-                "name": "dataMarketAddress",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "createdAt",
-                "type": "uint256"
-            }
+        {
+            "internalType": "address",
+            "name": "ownerAddress",
+            "type": "address"
+        },
+        {
+            "internalType": "uint8",
+            "name": "epochSize",
+            "type": "uint8"
+        },
+        {
+            "internalType": "uint256",
+            "name": "sourceChainId",
+            "type": "uint256"
+        },
+        {
+            "internalType": "uint256",
+            "name": "sourceChainBlockTime",
+            "type": "uint256"
+        },
+        {
+            "internalType": "bool",
+            "name": "useBlockNumberAsEpochId",
+            "type": "bool"
+        },
+        {
+            "internalType": "bool",
+            "name": "enabled",
+            "type": "bool"
+        },
+        {
+            "internalType": "address",
+            "name": "dataMarketAddress",
+            "type": "address"
+        },
+        {
+            "internalType": "uint256",
+            "name": "createdAt",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        }
         ],
         "name": "dayCounter",
         "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        }
         ],
         "name": "deploymentBlockNumber",
         "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
@@ -1403,27 +1466,27 @@
         "inputs": [],
         "name": "enabledNodeCount",
         "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "epochId",
-                "type": "uint256"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        },
+        {
+            "internalType": "uint256",
+            "name": "epochId",
+            "type": "uint256"
+        }
         ],
         "name": "endBatchSubmissions",
         "outputs": [],
@@ -1432,117 +1495,117 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "epochId",
-                "type": "uint256"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        },
+        {
+            "internalType": "uint256",
+            "name": "epochId",
+            "type": "uint256"
+        }
         ],
         "name": "epochIdToBatchCids",
         "outputs": [
-            {
-                "internalType": "string[]",
-                "name": "",
-                "type": "string[]"
-            }
+        {
+            "internalType": "string[]",
+            "name": "",
+            "type": "string[]"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "epochId",
-                "type": "uint256"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        },
+        {
+            "internalType": "uint256",
+            "name": "epochId",
+            "type": "uint256"
+        }
         ],
         "name": "epochInfo",
         "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "timestamp",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "blocknumber",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "epochEnd",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "timestamp",
+            "type": "uint256"
+        },
+        {
+            "internalType": "uint256",
+            "name": "blocknumber",
+            "type": "uint256"
+        },
+        {
+            "internalType": "uint256",
+            "name": "epochEnd",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        }
         ],
         "name": "epochManager",
         "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
+        {
+            "internalType": "address",
+            "name": "",
+            "type": "address"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        }
         ],
         "name": "epochsInADay",
         "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            },
-            {
-                "internalType": "string",
-                "name": "batchCid",
-                "type": "string"
-            },
-            {
-                "internalType": "uint256",
-                "name": "epochId",
-                "type": "uint256"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        },
+        {
+            "internalType": "string",
+            "name": "batchCid",
+            "type": "string"
+        },
+        {
+            "internalType": "uint256",
+            "name": "epochId",
+            "type": "uint256"
+        }
         ],
         "name": "forceCompleteConsensusAttestations",
         "outputs": [],
@@ -1551,21 +1614,21 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "begin",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "end",
-                "type": "uint256"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        },
+        {
+            "internalType": "uint256",
+            "name": "begin",
+            "type": "uint256"
+        },
+        {
+            "internalType": "uint256",
+            "name": "end",
+            "type": "uint256"
+        }
         ],
         "name": "forceSkipEpoch",
         "outputs": [],
@@ -1574,122 +1637,122 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        }
         ],
         "name": "getEpochManager",
         "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
+        {
+            "internalType": "address",
+            "name": "",
+            "type": "address"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        }
         ],
         "name": "getSequencerId",
         "outputs": [
-            {
-                "internalType": "string",
-                "name": "",
-                "type": "string"
-            }
+        {
+            "internalType": "string",
+            "name": "",
+            "type": "string"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        }
         ],
         "name": "getSequencers",
         "outputs": [
-            {
-                "internalType": "address[]",
-                "name": "",
-                "type": "address[]"
-            }
+        {
+            "internalType": "address[]",
+            "name": "",
+            "type": "address[]"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        },
+        {
+            "internalType": "uint256",
+            "name": "slotId",
+            "type": "uint256"
+        }
+        ],
+        "name": "getSlotInfo",
+        "outputs": [
+        {
+            "components": [
             {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
+                "internalType": "uint256",
+                "name": "slotId",
+                "type": "uint256"
+            },
+            {
+                "internalType": "address",
+                "name": "snapshotterAddress",
                 "type": "address"
             },
             {
                 "internalType": "uint256",
-                "name": "slotId",
+                "name": "rewardPoints",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "currentDaySnapshotCount",
                 "type": "uint256"
             }
-        ],
-        "name": "getSlotInfo",
-        "outputs": [
-            {
-                "components": [
-                    {
-                        "internalType": "uint256",
-                        "name": "slotId",
-                        "type": "uint256"
-                    },
-                    {
-                        "internalType": "address",
-                        "name": "snapshotterAddress",
-                        "type": "address"
-                    },
-                    {
-                        "internalType": "uint256",
-                        "name": "rewardPoints",
-                        "type": "uint256"
-                    },
-                    {
-                        "internalType": "uint256",
-                        "name": "currentDaySnapshotCount",
-                        "type": "uint256"
-                    }
-                ],
-                "internalType": "struct PowerloomDataMarket.SlotInfo",
-                "name": "",
-                "type": "tuple"
-            }
+            ],
+            "internalType": "struct PowerloomDataMarket.SlotInfo",
+            "name": "",
+            "type": "tuple"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "slotId",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "slotId",
+            "type": "uint256"
+        }
         ],
         "name": "getSlotRewards",
         "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "rewards",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "rewards",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
@@ -1698,30 +1761,30 @@
         "inputs": [],
         "name": "getTotalNodeCount",
         "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        }
         ],
         "name": "getTotalSequencersCount",
         "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
@@ -1730,60 +1793,70 @@
         "inputs": [],
         "name": "getTotalSnapshotterCount",
         "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        }
         ],
         "name": "getTotalValidatorsCount",
         "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        }
         ],
         "name": "getValidators",
         "outputs": [
-            {
-                "internalType": "address[]",
-                "name": "",
-                "type": "address[]"
-            }
+        {
+            "internalType": "address[]",
+            "name": "",
+            "type": "address[]"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "address",
-                "name": "initialOwner",
-                "type": "address"
-            }
+        {
+            "internalType": "address",
+            "name": "initialOwner",
+            "type": "address"
+        },
+        {
+            "internalType": "address",
+            "name": "_snapshotterState",
+            "type": "address"
+        },
+        {
+            "internalType": "address",
+            "name": "_dataMarketFactory",
+            "type": "address"
+        }
         ],
         "name": "initialize",
         "outputs": [],
@@ -1792,64 +1865,64 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            },
-            {
-                "internalType": "string",
-                "name": "projectId",
-                "type": "string"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        },
+        {
+            "internalType": "string",
+            "name": "projectId",
+            "type": "string"
+        }
         ],
         "name": "lastFinalizedSnapshot",
         "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            },
-            {
-                "internalType": "string",
-                "name": "projectId",
-                "type": "string"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        },
+        {
+            "internalType": "string",
+            "name": "projectId",
+            "type": "string"
+        }
         ],
         "name": "lastSequencerFinalizedSnapshot",
         "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_dayCounter",
-                "type": "uint256"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        },
+        {
+            "internalType": "uint256",
+            "name": "_dayCounter",
+            "type": "uint256"
+        }
         ],
         "name": "loadCurrentDay",
         "outputs": [],
@@ -1858,26 +1931,26 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "slotId",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "dayId",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "snapshotCount",
-                "type": "uint256"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        },
+        {
+            "internalType": "uint256",
+            "name": "slotId",
+            "type": "uint256"
+        },
+        {
+            "internalType": "uint256",
+            "name": "dayId",
+            "type": "uint256"
+        },
+        {
+            "internalType": "uint256",
+            "name": "snapshotCount",
+            "type": "uint256"
+        }
         ],
         "name": "loadSlotSubmissions",
         "outputs": [],
@@ -1886,96 +1959,101 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            },
-            {
-                "internalType": "string",
-                "name": "batchCid",
-                "type": "string"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        },
+        {
+            "internalType": "string",
+            "name": "batchCid",
+            "type": "string"
+        }
         ],
         "name": "maxAttestationFinalizedRootHash",
         "outputs": [
-            {
-                "internalType": "bytes32",
-                "name": "",
-                "type": "bytes32"
-            }
+        {
+            "internalType": "bytes32",
+            "name": "",
+            "type": "bytes32"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            },
-            {
-                "internalType": "string",
-                "name": "batchCid",
-                "type": "string"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        },
+        {
+            "internalType": "string",
+            "name": "batchCid",
+            "type": "string"
+        }
         ],
         "name": "maxAttestationsCount",
         "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            },
-            {
-                "internalType": "string",
-                "name": "projectId",
-                "type": "string"
-            },
-            {
-                "internalType": "uint256",
-                "name": "epochId",
-                "type": "uint256"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        },
+        {
+            "internalType": "string",
+            "name": "projectId",
+            "type": "string"
+        },
+        {
+            "internalType": "uint256",
+            "name": "epochId",
+            "type": "uint256"
+        }
         ],
         "name": "maxSnapshotsCid",
         "outputs": [
-            {
-                "internalType": "string",
-                "name": "",
-                "type": "string"
-            }
+        {
+            "internalType": "string",
+            "name": "",
+            "type": "string"
+        },
+        {
+            "internalType": "enum PowerloomDataMarket.SnapshotStatus",
+            "name": "",
+            "type": "uint8"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        }
         ],
         "name": "minAttestationsForConsensus",
         "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
@@ -1984,35 +2062,48 @@
         "inputs": [],
         "name": "owner",
         "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
+        {
+            "internalType": "address",
+            "name": "",
+            "type": "address"
+        }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "pendingOwner",
+        "outputs": [
+        {
+            "internalType": "address",
+            "name": "",
+            "type": "address"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            },
-            {
-                "internalType": "string",
-                "name": "projectId",
-                "type": "string"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        },
+        {
+            "internalType": "string",
+            "name": "projectId",
+            "type": "string"
+        }
         ],
         "name": "projectFirstEpochId",
         "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
@@ -2021,32 +2112,32 @@
         "inputs": [],
         "name": "proxiableUUID",
         "outputs": [
-            {
-                "internalType": "bytes32",
-                "name": "",
-                "type": "bytes32"
-            }
+        {
+            "internalType": "bytes32",
+            "name": "",
+            "type": "bytes32"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "begin",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "end",
-                "type": "uint256"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        },
+        {
+            "internalType": "uint256",
+            "name": "begin",
+            "type": "uint256"
+        },
+        {
+            "internalType": "uint256",
+            "name": "end",
+            "type": "uint256"
+        }
         ],
         "name": "releaseEpoch",
         "outputs": [],
@@ -2062,54 +2153,54 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        }
         ],
         "name": "rewardPoolSize",
         "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        }
         ],
         "name": "rewardsEnabled",
         "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
+        {
+            "internalType": "bool",
+            "name": "",
+            "type": "bool"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            },
-            {
-                "internalType": "string",
-                "name": "_sequencerId",
-                "type": "string"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        },
+        {
+            "internalType": "string",
+            "name": "_sequencerId",
+            "type": "string"
+        }
         ],
         "name": "setSequencerId",
         "outputs": [],
@@ -2118,149 +2209,149 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "slotId",
-                "type": "uint256"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        },
+        {
+            "internalType": "uint256",
+            "name": "slotId",
+            "type": "uint256"
+        }
         ],
         "name": "slotRewardPoints",
         "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "name": "slotRewards",
         "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "slotId",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "slotId",
+            "type": "uint256"
+        }
         ],
         "name": "slotSnapshotterMapping",
         "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
+        {
+            "internalType": "address",
+            "name": "",
+            "type": "address"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "slotId",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "dayId",
-                "type": "uint256"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        },
+        {
+            "internalType": "uint256",
+            "name": "slotId",
+            "type": "uint256"
+        },
+        {
+            "internalType": "uint256",
+            "name": "dayId",
+            "type": "uint256"
+        }
         ],
         "name": "slotSubmissionCount",
         "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            },
-            {
-                "internalType": "string",
-                "name": "projectId",
-                "type": "string"
-            },
-            {
-                "internalType": "uint256",
-                "name": "epochId",
-                "type": "uint256"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        },
+        {
+            "internalType": "string",
+            "name": "projectId",
+            "type": "string"
+        },
+        {
+            "internalType": "uint256",
+            "name": "epochId",
+            "type": "uint256"
+        }
         ],
         "name": "snapshotStatus",
         "outputs": [
-            {
-                "internalType": "enum PowerloomDataMarket.SnapshotStatus",
-                "name": "status",
-                "type": "uint8"
-            },
-            {
-                "internalType": "string",
-                "name": "snapshotCid",
-                "type": "string"
-            },
-            {
-                "internalType": "uint256",
-                "name": "timestamp",
-                "type": "uint256"
-            }
+        {
+            "internalType": "enum PowerloomDataMarket.SnapshotStatus",
+            "name": "status",
+            "type": "uint8"
+        },
+        {
+            "internalType": "string",
+            "name": "snapshotCid",
+            "type": "string"
+        },
+        {
+            "internalType": "uint256",
+            "name": "timestamp",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        }
         ],
         "name": "snapshotSubmissionWindow",
         "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
@@ -2269,37 +2360,37 @@
         "inputs": [],
         "name": "snapshotterState",
         "outputs": [
-            {
-                "internalType": "contract PowerloomNodes",
-                "name": "",
-                "type": "address"
-            }
+        {
+            "internalType": "contract PowerloomNodes",
+            "name": "",
+            "type": "address"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            },
-            {
-                "internalType": "string",
-                "name": "batchCid",
-                "type": "string"
-            },
-            {
-                "internalType": "uint256",
-                "name": "epochId",
-                "type": "uint256"
-            },
-            {
-                "internalType": "bytes32",
-                "name": "finalizedCidsRootHash",
-                "type": "bytes32"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        },
+        {
+            "internalType": "string",
+            "name": "batchCid",
+            "type": "string"
+        },
+        {
+            "internalType": "uint256",
+            "name": "epochId",
+            "type": "uint256"
+        },
+        {
+            "internalType": "bytes32",
+            "name": "finalizedCidsRootHash",
+            "type": "bytes32"
+        }
         ],
         "name": "submitBatchAttestation",
         "outputs": [],
@@ -2308,36 +2399,36 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            },
-            {
-                "internalType": "string",
-                "name": "batchCid",
-                "type": "string"
-            },
-            {
-                "internalType": "uint256",
-                "name": "epochId",
-                "type": "uint256"
-            },
-            {
-                "internalType": "string[]",
-                "name": "projectIds",
-                "type": "string[]"
-            },
-            {
-                "internalType": "string[]",
-                "name": "snapshotCids",
-                "type": "string[]"
-            },
-            {
-                "internalType": "bytes32",
-                "name": "finalizedCidsRootHash",
-                "type": "bytes32"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        },
+        {
+            "internalType": "string",
+            "name": "batchCid",
+            "type": "string"
+        },
+        {
+            "internalType": "uint256",
+            "name": "epochId",
+            "type": "uint256"
+        },
+        {
+            "internalType": "string[]",
+            "name": "projectIds",
+            "type": "string[]"
+        },
+        {
+            "internalType": "string[]",
+            "name": "snapshotCids",
+            "type": "string[]"
+        },
+        {
+            "internalType": "bytes32",
+            "name": "finalizedCidsRootHash",
+            "type": "bytes32"
+        }
         ],
         "name": "submitSubmissionBatch",
         "outputs": [],
@@ -2346,16 +2437,16 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "address",
-                "name": "dataMarketAddress",
-                "type": "address"
-            },
-            {
-                "internalType": "bool",
-                "name": "enabled",
-                "type": "bool"
-            }
+        {
+            "internalType": "address",
+            "name": "dataMarketAddress",
+            "type": "address"
+        },
+        {
+            "internalType": "bool",
+            "name": "enabled",
+            "type": "bool"
+        }
         ],
         "name": "toggleDataMarket",
         "outputs": [],
@@ -2364,11 +2455,11 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        }
         ],
         "name": "toggleRewards",
         "outputs": [],
@@ -2377,11 +2468,11 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "address",
-                "name": "newOwner",
-                "type": "address"
-            }
+        {
+            "internalType": "address",
+            "name": "newOwner",
+            "type": "address"
+        }
         ],
         "name": "transferOwnership",
         "outputs": [],
@@ -2390,26 +2481,26 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            },
-            {
-                "internalType": "enum PowerloomDataMarket.Role",
-                "name": "role",
-                "type": "uint8"
-            },
-            {
-                "internalType": "address[]",
-                "name": "_addresses",
-                "type": "address[]"
-            },
-            {
-                "internalType": "bool[]",
-                "name": "_status",
-                "type": "bool[]"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        },
+        {
+            "internalType": "enum PowerloomDataMarket.Role",
+            "name": "role",
+            "type": "uint8"
+        },
+        {
+            "internalType": "address[]",
+            "name": "_addresses",
+            "type": "address[]"
+        },
+        {
+            "internalType": "bool[]",
+            "name": "_status",
+            "type": "bool[]"
+        }
         ],
         "name": "updateAddresses",
         "outputs": [],
@@ -2418,16 +2509,16 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "newattestationSubmissionWindow",
-                "type": "uint256"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        },
+        {
+            "internalType": "uint256",
+            "name": "newattestationSubmissionWindow",
+            "type": "uint256"
+        }
         ],
         "name": "updateAttestationSubmissionWindow",
         "outputs": [],
@@ -2436,16 +2527,16 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "newbatchSubmissionWindow",
-                "type": "uint256"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        },
+        {
+            "internalType": "uint256",
+            "name": "newbatchSubmissionWindow",
+            "type": "uint256"
+        }
         ],
         "name": "updateBatchSubmissionWindow",
         "outputs": [],
@@ -2454,16 +2545,16 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_dailySnapshotQuota",
-                "type": "uint256"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        },
+        {
+            "internalType": "uint256",
+            "name": "_dailySnapshotQuota",
+            "type": "uint256"
+        }
         ],
         "name": "updateDailySnapshotQuota",
         "outputs": [],
@@ -2472,11 +2563,11 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "address",
-                "name": "_address",
-                "type": "address"
-            }
+        {
+            "internalType": "address",
+            "name": "_address",
+            "type": "address"
+        }
         ],
         "name": "updateDataMarketFactory",
         "outputs": [],
@@ -2485,34 +2576,16 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "newDaySize",
-                "type": "uint256"
-            }
-        ],
-        "name": "updateDaySize",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            },
-            {
-                "internalType": "address",
-                "name": "_address",
-                "type": "address"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        },
+        {
+            "internalType": "address",
+            "name": "_address",
+            "type": "address"
+        }
         ],
         "name": "updateEpochManager",
         "outputs": [],
@@ -2521,16 +2594,16 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_minAttestationsForConsensus",
-                "type": "uint256"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        },
+        {
+            "internalType": "uint256",
+            "name": "_minAttestationsForConsensus",
+            "type": "uint256"
+        }
         ],
         "name": "updateMinAttestationsForConsensus",
         "outputs": [],
@@ -2539,16 +2612,16 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "newRewardPoolSize",
-                "type": "uint256"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        },
+        {
+            "internalType": "uint256",
+            "name": "newRewardPoolSize",
+            "type": "uint256"
+        }
         ],
         "name": "updateRewardPoolSize",
         "outputs": [],
@@ -2557,31 +2630,31 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256[]",
-                "name": "slotIds",
-                "type": "uint256[]"
-            },
-            {
-                "internalType": "uint256[]",
-                "name": "submissionsList",
-                "type": "uint256[]"
-            },
-            {
-                "internalType": "uint256",
-                "name": "day",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "eligibleNodes",
-                "type": "uint256"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        },
+        {
+            "internalType": "uint256[]",
+            "name": "slotIds",
+            "type": "uint256[]"
+        },
+        {
+            "internalType": "uint256[]",
+            "name": "submissionsList",
+            "type": "uint256[]"
+        },
+        {
+            "internalType": "uint256",
+            "name": "day",
+            "type": "uint256"
+        },
+        {
+            "internalType": "uint256",
+            "name": "eligibleNodes",
+            "type": "uint256"
+        }
         ],
         "name": "updateRewards",
         "outputs": [],
@@ -2590,16 +2663,16 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "contract PowerloomDataMarket",
-                "name": "dataMarket",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "newsnapshotSubmissionWindow",
-                "type": "uint256"
-            }
+        {
+            "internalType": "contract PowerloomDataMarket",
+            "name": "dataMarket",
+            "type": "address"
+        },
+        {
+            "internalType": "uint256",
+            "name": "newsnapshotSubmissionWindow",
+            "type": "uint256"
+        }
         ],
         "name": "updateSnapshotSubmissionWindow",
         "outputs": [],
@@ -2608,11 +2681,11 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "address",
-                "name": "_address",
-                "type": "address"
-            }
+        {
+            "internalType": "address",
+            "name": "_address",
+            "type": "address"
+        }
         ],
         "name": "updateSnapshotterState",
         "outputs": [],
@@ -2621,16 +2694,16 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "address",
-                "name": "newImplementation",
-                "type": "address"
-            },
-            {
-                "internalType": "bytes",
-                "name": "data",
-                "type": "bytes"
-            }
+        {
+            "internalType": "address",
+            "name": "newImplementation",
+            "type": "address"
+        },
+        {
+            "internalType": "bytes",
+            "name": "data",
+            "type": "bytes"
+        }
         ],
         "name": "upgradeToAndCall",
         "outputs": [],
@@ -2639,36 +2712,40 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
+        {
+            "internalType": "address",
+            "name": "",
+            "type": "address"
+        }
         ],
         "name": "userInfo",
         "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "totalRewards",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "totalClaimed",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "lastClaimed",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "lastUpdated",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "totalRewards",
+            "type": "uint256"
+        },
+        {
+            "internalType": "uint256",
+            "name": "totalClaimed",
+            "type": "uint256"
+        },
+        {
+            "internalType": "uint256",
+            "name": "lastClaimed",
+            "type": "uint256"
+        },
+        {
+            "internalType": "uint256",
+            "name": "lastUpdated",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
+    },
+    {
+        "stateMutability": "payable",
+        "type": "receive"
     }
 ]

--- a/pkgs/contract/contract.go
+++ b/pkgs/contract/contract.go
@@ -39,7 +39,7 @@ type PowerloomDataMarketSlotInfo struct {
 
 // ContractMetaData contains all meta data concerning the Contract contract.
 var ContractMetaData = &bind.MetaData{
-	ABI: "[{\"inputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"target\",\"type\":\"address\"}],\"name\":\"AddressEmptyCode\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"implementation\",\"type\":\"address\"}],\"name\":\"ERC1967InvalidImplementation\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"ERC1967NonPayable\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"FailedInnerCall\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidInitialization\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"NotInitializing\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"OwnableInvalidOwner\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"OwnableUnauthorizedAccount\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"UUPSUnauthorizedCallContext\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"slot\",\"type\":\"bytes32\"}],\"name\":\"UUPSUnsupportedProxiableUUID\",\"type\":\"error\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"dataMarketAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"adminAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"bool\",\"name\":\"allowed\",\"type\":\"bool\"}],\"name\":\"AdminsUpdated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"dataMarketAddress\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"epochId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"timestamp\",\"type\":\"uint256\"}],\"name\":\"BatchSubmissionsCompleted\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"dataMarketAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"snapshotterAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"slotId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"dayId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"rewardPoints\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"timestamp\",\"type\":\"uint256\"}],\"name\":\"DailyTaskCompletedEvent\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"ownerAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"epochSize\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"sourceChainId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"sourceChainBlockTime\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"bool\",\"name\":\"useBlockNumberAsEpochId\",\"type\":\"bool\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"protocolState\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"dataMarketAddress\",\"type\":\"address\"}],\"name\":\"DataMarketCreated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"dataMarketAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"dayId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"timestamp\",\"type\":\"uint256\"}],\"name\":\"DayStartedEvent\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"dataMarketAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"string\",\"name\":\"batchCid\",\"type\":\"string\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"epochId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"timestamp\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"validatorAddr\",\"type\":\"address\"}],\"name\":\"DelayedAttestationSubmitted\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"dataMarketAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"string\",\"name\":\"batchCid\",\"type\":\"string\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"epochId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"timestamp\",\"type\":\"uint256\"}],\"name\":\"DelayedBatchSubmitted\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"dataMarketAddress\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"snapshotterAddr\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"slotId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"string\",\"name\":\"snapshotCid\",\"type\":\"string\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"epochId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"string\",\"name\":\"projectId\",\"type\":\"string\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"timestamp\",\"type\":\"uint256\"}],\"name\":\"DelayedSnapshotSubmitted\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"EmergencyWithdraw\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"dataMarketAddress\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"epochId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"begin\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"end\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"timestamp\",\"type\":\"uint256\"}],\"name\":\"EpochReleased\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"version\",\"type\":\"uint64\"}],\"name\":\"Initialized\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"previousOwner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"OwnershipTransferred\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"user\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"timestamp\",\"type\":\"uint256\"}],\"name\":\"RewardsClaimed\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"dataMarketAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"sequencerAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"bool\",\"name\":\"allowed\",\"type\":\"bool\"}],\"name\":\"SequencersUpdated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"dataMarketAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"string\",\"name\":\"batchCid\",\"type\":\"string\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"epochId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"timestamp\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"validatorAddr\",\"type\":\"address\"}],\"name\":\"SnapshotBatchAttestationSubmitted\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"dataMarketAddress\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"epochId\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"string\",\"name\":\"batchCid\",\"type\":\"string\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"timestamp\",\"type\":\"uint256\"}],\"name\":\"SnapshotBatchFinalized\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"dataMarketAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"string\",\"name\":\"batchCid\",\"type\":\"string\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"epochId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"timestamp\",\"type\":\"uint256\"}],\"name\":\"SnapshotBatchSubmitted\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"dataMarketAddress\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"epochId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"epochEnd\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"string\",\"name\":\"projectId\",\"type\":\"string\"},{\"indexed\":false,\"internalType\":\"string\",\"name\":\"snapshotCid\",\"type\":\"string\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"timestamp\",\"type\":\"uint256\"}],\"name\":\"SnapshotFinalized\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"dataMarketAddress\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"epochId\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"string\",\"name\":\"batchCid\",\"type\":\"string\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"timestamp\",\"type\":\"uint256\"}],\"name\":\"TriggerBatchResubmission\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"implementation\",\"type\":\"address\"}],\"name\":\"Upgraded\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"dataMarketAddress\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"epochId\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"string\",\"name\":\"batchCid\",\"type\":\"string\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"validator\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"timestamp\",\"type\":\"uint256\"}],\"name\":\"ValidatorAttestationsInvalidated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"dataMarketAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"validatorAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"bool\",\"name\":\"allowed\",\"type\":\"bool\"}],\"name\":\"ValidatorsUpdated\",\"type\":\"event\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"}],\"name\":\"DAY_SIZE\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"}],\"name\":\"EPOCH_SIZE\",\"outputs\":[{\"internalType\":\"uint8\",\"name\":\"\",\"type\":\"uint8\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"}],\"name\":\"SOURCE_CHAIN_BLOCK_TIME\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"}],\"name\":\"SOURCE_CHAIN_ID\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"UPGRADE_INTERFACE_VERSION\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"}],\"name\":\"USE_BLOCK_NUMBER_AS_EPOCH_ID\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"allSnapshotters\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"}],\"name\":\"attestationSubmissionWindow\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"string\",\"name\":\"batchCid\",\"type\":\"string\"},{\"internalType\":\"address\",\"name\":\"validator\",\"type\":\"address\"}],\"name\":\"attestationsReceived\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"string\",\"name\":\"batchCid\",\"type\":\"string\"},{\"internalType\":\"bytes32\",\"name\":\"finalizedCidsRootHash\",\"type\":\"bytes32\"}],\"name\":\"attestationsReceivedCount\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"string\",\"name\":\"batchCid\",\"type\":\"string\"}],\"name\":\"batchCidAttestationStatus\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"string\",\"name\":\"batchCid\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"idx\",\"type\":\"uint256\"}],\"name\":\"batchCidDivergentValidators\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"string\",\"name\":\"batchCid\",\"type\":\"string\"}],\"name\":\"batchCidSequencerAttestation\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"string\",\"name\":\"batchCid\",\"type\":\"string\"}],\"name\":\"batchCidToProjects\",\"outputs\":[{\"internalType\":\"string[]\",\"name\":\"\",\"type\":\"string[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"}],\"name\":\"batchSubmissionWindow\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"string\",\"name\":\"batchCid\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"epochId\",\"type\":\"uint256\"}],\"name\":\"checkDynamicConsensusAttestations\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"slotId\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"day\",\"type\":\"uint256\"}],\"name\":\"checkSlotTaskStatusForDay\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_user\",\"type\":\"address\"}],\"name\":\"claimRewards\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"ownerAddress\",\"type\":\"address\"},{\"internalType\":\"uint8\",\"name\":\"epochSize\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"sourceChainId\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"sourceChainBlockTime\",\"type\":\"uint256\"},{\"internalType\":\"bool\",\"name\":\"useBlockNumberAsEpochId\",\"type\":\"bool\"}],\"name\":\"createDataMarket\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"}],\"name\":\"currentEpoch\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"begin\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"end\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"epochId\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"}],\"name\":\"dailySnapshotQuota\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"dataMarketCount\",\"outputs\":[{\"internalType\":\"uint8\",\"name\":\"\",\"type\":\"uint8\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"dataMarketAddress\",\"type\":\"address\"}],\"name\":\"dataMarketEnabled\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"dataMarketFactory\",\"outputs\":[{\"internalType\":\"contractDataMarketFactory\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint8\",\"name\":\"dataMarketId\",\"type\":\"uint8\"}],\"name\":\"dataMarketIdToAddress\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"dataMarketAddress\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"name\":\"dataMarkets\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"ownerAddress\",\"type\":\"address\"},{\"internalType\":\"uint8\",\"name\":\"epochSize\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"sourceChainId\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"sourceChainBlockTime\",\"type\":\"uint256\"},{\"internalType\":\"bool\",\"name\":\"useBlockNumberAsEpochId\",\"type\":\"bool\"},{\"internalType\":\"bool\",\"name\":\"enabled\",\"type\":\"bool\"},{\"internalType\":\"address\",\"name\":\"dataMarketAddress\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"createdAt\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"}],\"name\":\"dayCounter\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"}],\"name\":\"deploymentBlockNumber\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"emergencyWithdraw\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"enabledNodeCount\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"epochId\",\"type\":\"uint256\"}],\"name\":\"endBatchSubmissions\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"epochId\",\"type\":\"uint256\"}],\"name\":\"epochIdToBatchCids\",\"outputs\":[{\"internalType\":\"string[]\",\"name\":\"\",\"type\":\"string[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"epochId\",\"type\":\"uint256\"}],\"name\":\"epochInfo\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"timestamp\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"blocknumber\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"epochEnd\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"}],\"name\":\"epochManager\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"}],\"name\":\"epochsInADay\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"string\",\"name\":\"batchCid\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"epochId\",\"type\":\"uint256\"}],\"name\":\"forceCompleteConsensusAttestations\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"begin\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"end\",\"type\":\"uint256\"}],\"name\":\"forceSkipEpoch\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"}],\"name\":\"getEpochManager\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"}],\"name\":\"getSequencerId\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"}],\"name\":\"getSequencers\",\"outputs\":[{\"internalType\":\"address[]\",\"name\":\"\",\"type\":\"address[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"slotId\",\"type\":\"uint256\"}],\"name\":\"getSlotInfo\",\"outputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"slotId\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"snapshotterAddress\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"rewardPoints\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"currentDaySnapshotCount\",\"type\":\"uint256\"}],\"internalType\":\"structPowerloomDataMarket.SlotInfo\",\"name\":\"\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"slotId\",\"type\":\"uint256\"}],\"name\":\"getSlotRewards\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"rewards\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getTotalNodeCount\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"}],\"name\":\"getTotalSequencersCount\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getTotalSnapshotterCount\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"}],\"name\":\"getTotalValidatorsCount\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"}],\"name\":\"getValidators\",\"outputs\":[{\"internalType\":\"address[]\",\"name\":\"\",\"type\":\"address[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"initialOwner\",\"type\":\"address\"}],\"name\":\"initialize\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"string\",\"name\":\"projectId\",\"type\":\"string\"}],\"name\":\"lastFinalizedSnapshot\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"string\",\"name\":\"projectId\",\"type\":\"string\"}],\"name\":\"lastSequencerFinalizedSnapshot\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"_dayCounter\",\"type\":\"uint256\"}],\"name\":\"loadCurrentDay\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"slotId\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"dayId\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"snapshotCount\",\"type\":\"uint256\"}],\"name\":\"loadSlotSubmissions\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"string\",\"name\":\"batchCid\",\"type\":\"string\"}],\"name\":\"maxAttestationFinalizedRootHash\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"string\",\"name\":\"batchCid\",\"type\":\"string\"}],\"name\":\"maxAttestationsCount\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"string\",\"name\":\"projectId\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"epochId\",\"type\":\"uint256\"}],\"name\":\"maxSnapshotsCid\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"}],\"name\":\"minAttestationsForConsensus\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"string\",\"name\":\"projectId\",\"type\":\"string\"}],\"name\":\"projectFirstEpochId\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"proxiableUUID\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"begin\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"end\",\"type\":\"uint256\"}],\"name\":\"releaseEpoch\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"renounceOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"}],\"name\":\"rewardPoolSize\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"}],\"name\":\"rewardsEnabled\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"string\",\"name\":\"_sequencerId\",\"type\":\"string\"}],\"name\":\"setSequencerId\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"slotId\",\"type\":\"uint256\"}],\"name\":\"slotRewardPoints\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"slotRewards\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"slotId\",\"type\":\"uint256\"}],\"name\":\"slotSnapshotterMapping\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"slotId\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"dayId\",\"type\":\"uint256\"}],\"name\":\"slotSubmissionCount\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"string\",\"name\":\"projectId\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"epochId\",\"type\":\"uint256\"}],\"name\":\"snapshotStatus\",\"outputs\":[{\"internalType\":\"enumPowerloomDataMarket.SnapshotStatus\",\"name\":\"status\",\"type\":\"uint8\"},{\"internalType\":\"string\",\"name\":\"snapshotCid\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"timestamp\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"}],\"name\":\"snapshotSubmissionWindow\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"snapshotterState\",\"outputs\":[{\"internalType\":\"contractPowerloomNodes\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"string\",\"name\":\"batchCid\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"epochId\",\"type\":\"uint256\"},{\"internalType\":\"bytes32\",\"name\":\"finalizedCidsRootHash\",\"type\":\"bytes32\"}],\"name\":\"submitBatchAttestation\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"string\",\"name\":\"batchCid\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"epochId\",\"type\":\"uint256\"},{\"internalType\":\"string[]\",\"name\":\"projectIds\",\"type\":\"string[]\"},{\"internalType\":\"string[]\",\"name\":\"snapshotCids\",\"type\":\"string[]\"},{\"internalType\":\"bytes32\",\"name\":\"finalizedCidsRootHash\",\"type\":\"bytes32\"}],\"name\":\"submitSubmissionBatch\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"dataMarketAddress\",\"type\":\"address\"},{\"internalType\":\"bool\",\"name\":\"enabled\",\"type\":\"bool\"}],\"name\":\"toggleDataMarket\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"}],\"name\":\"toggleRewards\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"transferOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"enumPowerloomDataMarket.Role\",\"name\":\"role\",\"type\":\"uint8\"},{\"internalType\":\"address[]\",\"name\":\"_addresses\",\"type\":\"address[]\"},{\"internalType\":\"bool[]\",\"name\":\"_status\",\"type\":\"bool[]\"}],\"name\":\"updateAddresses\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"newattestationSubmissionWindow\",\"type\":\"uint256\"}],\"name\":\"updateAttestationSubmissionWindow\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"newbatchSubmissionWindow\",\"type\":\"uint256\"}],\"name\":\"updateBatchSubmissionWindow\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"_dailySnapshotQuota\",\"type\":\"uint256\"}],\"name\":\"updateDailySnapshotQuota\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_address\",\"type\":\"address\"}],\"name\":\"updateDataMarketFactory\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"newDaySize\",\"type\":\"uint256\"}],\"name\":\"updateDaySize\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"_address\",\"type\":\"address\"}],\"name\":\"updateEpochManager\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"_minAttestationsForConsensus\",\"type\":\"uint256\"}],\"name\":\"updateMinAttestationsForConsensus\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"newRewardPoolSize\",\"type\":\"uint256\"}],\"name\":\"updateRewardPoolSize\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"uint256[]\",\"name\":\"slotIds\",\"type\":\"uint256[]\"},{\"internalType\":\"uint256[]\",\"name\":\"submissionsList\",\"type\":\"uint256[]\"},{\"internalType\":\"uint256\",\"name\":\"day\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"eligibleNodes\",\"type\":\"uint256\"}],\"name\":\"updateRewards\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"newsnapshotSubmissionWindow\",\"type\":\"uint256\"}],\"name\":\"updateSnapshotSubmissionWindow\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_address\",\"type\":\"address\"}],\"name\":\"updateSnapshotterState\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newImplementation\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"}],\"name\":\"upgradeToAndCall\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"name\":\"userInfo\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"totalRewards\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"totalClaimed\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"lastClaimed\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"lastUpdated\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"}]",
+	ABI: "[{\"inputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"target\",\"type\":\"address\"}],\"name\":\"AddressEmptyCode\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"implementation\",\"type\":\"address\"}],\"name\":\"ERC1967InvalidImplementation\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"ERC1967NonPayable\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"FailedCall\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidInitialization\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"NotInitializing\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"OwnableInvalidOwner\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"OwnableUnauthorizedAccount\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"UUPSUnauthorizedCallContext\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"slot\",\"type\":\"bytes32\"}],\"name\":\"UUPSUnsupportedProxiableUUID\",\"type\":\"error\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"dataMarketAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"adminAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"bool\",\"name\":\"allowed\",\"type\":\"bool\"}],\"name\":\"AdminsUpdated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"dataMarketAddress\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"epochId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"timestamp\",\"type\":\"uint256\"}],\"name\":\"BatchSubmissionsCompleted\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"dataMarketAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"snapshotterAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"slotId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"dayId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"timestamp\",\"type\":\"uint256\"}],\"name\":\"DailyTaskCompletedEvent\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"ownerAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"epochSize\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"sourceChainId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"sourceChainBlockTime\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"bool\",\"name\":\"useBlockNumberAsEpochId\",\"type\":\"bool\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"protocolState\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"dataMarketAddress\",\"type\":\"address\"}],\"name\":\"DataMarketCreated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"dataMarketAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"dayId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"timestamp\",\"type\":\"uint256\"}],\"name\":\"DayStartedEvent\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"dataMarketAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"string\",\"name\":\"batchCid\",\"type\":\"string\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"epochId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"timestamp\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"validatorAddr\",\"type\":\"address\"}],\"name\":\"DelayedAttestationSubmitted\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"dataMarketAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"string\",\"name\":\"batchCid\",\"type\":\"string\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"epochId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"timestamp\",\"type\":\"uint256\"}],\"name\":\"DelayedBatchSubmitted\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"dataMarketAddress\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"snapshotterAddr\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"slotId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"string\",\"name\":\"snapshotCid\",\"type\":\"string\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"epochId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"string\",\"name\":\"projectId\",\"type\":\"string\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"timestamp\",\"type\":\"uint256\"}],\"name\":\"DelayedSnapshotSubmitted\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"EmergencyWithdraw\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"dataMarketAddress\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"epochId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"begin\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"end\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"timestamp\",\"type\":\"uint256\"}],\"name\":\"EpochReleased\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"version\",\"type\":\"uint64\"}],\"name\":\"Initialized\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"previousOwner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"OwnershipTransferStarted\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"previousOwner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"OwnershipTransferred\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"user\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"timestamp\",\"type\":\"uint256\"}],\"name\":\"RewardsClaimed\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"dataMarketAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"snapshotterAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"slotId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"dayId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"rewardPoints\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"timestamp\",\"type\":\"uint256\"}],\"name\":\"RewardsDistributedEvent\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"dataMarketAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"sequencerAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"bool\",\"name\":\"allowed\",\"type\":\"bool\"}],\"name\":\"SequencersUpdated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"dataMarketAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"string\",\"name\":\"batchCid\",\"type\":\"string\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"epochId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"timestamp\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"validatorAddr\",\"type\":\"address\"}],\"name\":\"SnapshotBatchAttestationSubmitted\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"dataMarketAddress\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"epochId\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"string\",\"name\":\"batchCid\",\"type\":\"string\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"timestamp\",\"type\":\"uint256\"}],\"name\":\"SnapshotBatchFinalized\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"dataMarketAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"string\",\"name\":\"batchCid\",\"type\":\"string\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"epochId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"timestamp\",\"type\":\"uint256\"}],\"name\":\"SnapshotBatchSubmitted\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"dataMarketAddress\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"epochId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"epochEnd\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"string\",\"name\":\"projectId\",\"type\":\"string\"},{\"indexed\":false,\"internalType\":\"string\",\"name\":\"snapshotCid\",\"type\":\"string\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"timestamp\",\"type\":\"uint256\"}],\"name\":\"SnapshotFinalized\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"dataMarketAddress\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"epochId\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"string\",\"name\":\"batchCid\",\"type\":\"string\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"timestamp\",\"type\":\"uint256\"}],\"name\":\"TriggerBatchResubmission\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"implementation\",\"type\":\"address\"}],\"name\":\"Upgraded\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"dataMarketAddress\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"epochId\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"string\",\"name\":\"batchCid\",\"type\":\"string\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"validator\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"timestamp\",\"type\":\"uint256\"}],\"name\":\"ValidatorAttestationsInvalidated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"dataMarketAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"validatorAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"bool\",\"name\":\"allowed\",\"type\":\"bool\"}],\"name\":\"ValidatorsUpdated\",\"type\":\"event\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"}],\"name\":\"DAY_SIZE\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"}],\"name\":\"EPOCH_SIZE\",\"outputs\":[{\"internalType\":\"uint8\",\"name\":\"\",\"type\":\"uint8\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"}],\"name\":\"SOURCE_CHAIN_BLOCK_TIME\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"}],\"name\":\"SOURCE_CHAIN_ID\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"UPGRADE_INTERFACE_VERSION\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"}],\"name\":\"USE_BLOCK_NUMBER_AS_EPOCH_ID\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"acceptOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"allSnapshotters\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"}],\"name\":\"attestationSubmissionWindow\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"string\",\"name\":\"batchCid\",\"type\":\"string\"},{\"internalType\":\"address\",\"name\":\"validator\",\"type\":\"address\"}],\"name\":\"attestationsReceived\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"string\",\"name\":\"batchCid\",\"type\":\"string\"},{\"internalType\":\"bytes32\",\"name\":\"finalizedCidsRootHash\",\"type\":\"bytes32\"}],\"name\":\"attestationsReceivedCount\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"string\",\"name\":\"batchCid\",\"type\":\"string\"}],\"name\":\"batchCidAttestationStatus\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"string\",\"name\":\"batchCid\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"idx\",\"type\":\"uint256\"}],\"name\":\"batchCidDivergentValidators\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"string\",\"name\":\"batchCid\",\"type\":\"string\"}],\"name\":\"batchCidSequencerAttestation\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"string\",\"name\":\"batchCid\",\"type\":\"string\"}],\"name\":\"batchCidToProjects\",\"outputs\":[{\"internalType\":\"string[]\",\"name\":\"\",\"type\":\"string[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"}],\"name\":\"batchSubmissionWindow\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"string\",\"name\":\"batchCid\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"epochId\",\"type\":\"uint256\"}],\"name\":\"checkDynamicConsensusAttestations\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"slotId\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"day\",\"type\":\"uint256\"}],\"name\":\"checkSlotTaskStatusForDay\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_user\",\"type\":\"address\"}],\"name\":\"claimRewards\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"ownerAddress\",\"type\":\"address\"},{\"internalType\":\"uint8\",\"name\":\"epochSize\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"sourceChainId\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"sourceChainBlockTime\",\"type\":\"uint256\"},{\"internalType\":\"bool\",\"name\":\"useBlockNumberAsEpochId\",\"type\":\"bool\"}],\"name\":\"createDataMarket\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"}],\"name\":\"currentEpoch\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"begin\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"end\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"epochId\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"}],\"name\":\"dailySnapshotQuota\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"dataMarketCount\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"dataMarketAddress\",\"type\":\"address\"}],\"name\":\"dataMarketEnabled\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"dataMarketFactory\",\"outputs\":[{\"internalType\":\"contractDataMarketFactory\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"dataMarketId\",\"type\":\"uint256\"}],\"name\":\"dataMarketIdToAddress\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"dataMarketAddress\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"name\":\"dataMarkets\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"ownerAddress\",\"type\":\"address\"},{\"internalType\":\"uint8\",\"name\":\"epochSize\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"sourceChainId\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"sourceChainBlockTime\",\"type\":\"uint256\"},{\"internalType\":\"bool\",\"name\":\"useBlockNumberAsEpochId\",\"type\":\"bool\"},{\"internalType\":\"bool\",\"name\":\"enabled\",\"type\":\"bool\"},{\"internalType\":\"address\",\"name\":\"dataMarketAddress\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"createdAt\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"}],\"name\":\"dayCounter\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"}],\"name\":\"deploymentBlockNumber\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"emergencyWithdraw\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"enabledNodeCount\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"epochId\",\"type\":\"uint256\"}],\"name\":\"endBatchSubmissions\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"epochId\",\"type\":\"uint256\"}],\"name\":\"epochIdToBatchCids\",\"outputs\":[{\"internalType\":\"string[]\",\"name\":\"\",\"type\":\"string[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"epochId\",\"type\":\"uint256\"}],\"name\":\"epochInfo\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"timestamp\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"blocknumber\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"epochEnd\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"}],\"name\":\"epochManager\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"}],\"name\":\"epochsInADay\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"string\",\"name\":\"batchCid\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"epochId\",\"type\":\"uint256\"}],\"name\":\"forceCompleteConsensusAttestations\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"begin\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"end\",\"type\":\"uint256\"}],\"name\":\"forceSkipEpoch\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"}],\"name\":\"getEpochManager\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"}],\"name\":\"getSequencerId\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"}],\"name\":\"getSequencers\",\"outputs\":[{\"internalType\":\"address[]\",\"name\":\"\",\"type\":\"address[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"slotId\",\"type\":\"uint256\"}],\"name\":\"getSlotInfo\",\"outputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"slotId\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"snapshotterAddress\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"rewardPoints\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"currentDaySnapshotCount\",\"type\":\"uint256\"}],\"internalType\":\"structPowerloomDataMarket.SlotInfo\",\"name\":\"\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"slotId\",\"type\":\"uint256\"}],\"name\":\"getSlotRewards\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"rewards\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getTotalNodeCount\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"}],\"name\":\"getTotalSequencersCount\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getTotalSnapshotterCount\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"}],\"name\":\"getTotalValidatorsCount\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"}],\"name\":\"getValidators\",\"outputs\":[{\"internalType\":\"address[]\",\"name\":\"\",\"type\":\"address[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"initialOwner\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"_snapshotterState\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"_dataMarketFactory\",\"type\":\"address\"}],\"name\":\"initialize\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"string\",\"name\":\"projectId\",\"type\":\"string\"}],\"name\":\"lastFinalizedSnapshot\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"string\",\"name\":\"projectId\",\"type\":\"string\"}],\"name\":\"lastSequencerFinalizedSnapshot\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"_dayCounter\",\"type\":\"uint256\"}],\"name\":\"loadCurrentDay\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"slotId\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"dayId\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"snapshotCount\",\"type\":\"uint256\"}],\"name\":\"loadSlotSubmissions\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"string\",\"name\":\"batchCid\",\"type\":\"string\"}],\"name\":\"maxAttestationFinalizedRootHash\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"string\",\"name\":\"batchCid\",\"type\":\"string\"}],\"name\":\"maxAttestationsCount\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"string\",\"name\":\"projectId\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"epochId\",\"type\":\"uint256\"}],\"name\":\"maxSnapshotsCid\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"},{\"internalType\":\"enumPowerloomDataMarket.SnapshotStatus\",\"name\":\"\",\"type\":\"uint8\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"}],\"name\":\"minAttestationsForConsensus\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"pendingOwner\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"string\",\"name\":\"projectId\",\"type\":\"string\"}],\"name\":\"projectFirstEpochId\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"proxiableUUID\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"begin\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"end\",\"type\":\"uint256\"}],\"name\":\"releaseEpoch\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"renounceOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"}],\"name\":\"rewardPoolSize\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"}],\"name\":\"rewardsEnabled\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"string\",\"name\":\"_sequencerId\",\"type\":\"string\"}],\"name\":\"setSequencerId\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"slotId\",\"type\":\"uint256\"}],\"name\":\"slotRewardPoints\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"slotRewards\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"slotId\",\"type\":\"uint256\"}],\"name\":\"slotSnapshotterMapping\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"slotId\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"dayId\",\"type\":\"uint256\"}],\"name\":\"slotSubmissionCount\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"string\",\"name\":\"projectId\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"epochId\",\"type\":\"uint256\"}],\"name\":\"snapshotStatus\",\"outputs\":[{\"internalType\":\"enumPowerloomDataMarket.SnapshotStatus\",\"name\":\"status\",\"type\":\"uint8\"},{\"internalType\":\"string\",\"name\":\"snapshotCid\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"timestamp\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"}],\"name\":\"snapshotSubmissionWindow\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"snapshotterState\",\"outputs\":[{\"internalType\":\"contractPowerloomNodes\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"string\",\"name\":\"batchCid\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"epochId\",\"type\":\"uint256\"},{\"internalType\":\"bytes32\",\"name\":\"finalizedCidsRootHash\",\"type\":\"bytes32\"}],\"name\":\"submitBatchAttestation\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"string\",\"name\":\"batchCid\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"epochId\",\"type\":\"uint256\"},{\"internalType\":\"string[]\",\"name\":\"projectIds\",\"type\":\"string[]\"},{\"internalType\":\"string[]\",\"name\":\"snapshotCids\",\"type\":\"string[]\"},{\"internalType\":\"bytes32\",\"name\":\"finalizedCidsRootHash\",\"type\":\"bytes32\"}],\"name\":\"submitSubmissionBatch\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"dataMarketAddress\",\"type\":\"address\"},{\"internalType\":\"bool\",\"name\":\"enabled\",\"type\":\"bool\"}],\"name\":\"toggleDataMarket\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"}],\"name\":\"toggleRewards\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"transferOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"enumPowerloomDataMarket.Role\",\"name\":\"role\",\"type\":\"uint8\"},{\"internalType\":\"address[]\",\"name\":\"_addresses\",\"type\":\"address[]\"},{\"internalType\":\"bool[]\",\"name\":\"_status\",\"type\":\"bool[]\"}],\"name\":\"updateAddresses\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"newattestationSubmissionWindow\",\"type\":\"uint256\"}],\"name\":\"updateAttestationSubmissionWindow\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"newbatchSubmissionWindow\",\"type\":\"uint256\"}],\"name\":\"updateBatchSubmissionWindow\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"_dailySnapshotQuota\",\"type\":\"uint256\"}],\"name\":\"updateDailySnapshotQuota\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_address\",\"type\":\"address\"}],\"name\":\"updateDataMarketFactory\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"_address\",\"type\":\"address\"}],\"name\":\"updateEpochManager\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"_minAttestationsForConsensus\",\"type\":\"uint256\"}],\"name\":\"updateMinAttestationsForConsensus\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"newRewardPoolSize\",\"type\":\"uint256\"}],\"name\":\"updateRewardPoolSize\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"uint256[]\",\"name\":\"slotIds\",\"type\":\"uint256[]\"},{\"internalType\":\"uint256[]\",\"name\":\"submissionsList\",\"type\":\"uint256[]\"},{\"internalType\":\"uint256\",\"name\":\"day\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"eligibleNodes\",\"type\":\"uint256\"}],\"name\":\"updateRewards\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractPowerloomDataMarket\",\"name\":\"dataMarket\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"newsnapshotSubmissionWindow\",\"type\":\"uint256\"}],\"name\":\"updateSnapshotSubmissionWindow\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_address\",\"type\":\"address\"}],\"name\":\"updateSnapshotterState\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newImplementation\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"}],\"name\":\"upgradeToAndCall\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"name\":\"userInfo\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"totalRewards\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"totalClaimed\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"lastClaimed\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"lastUpdated\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"stateMutability\":\"payable\",\"type\":\"receive\"}]",
 }
 
 // ContractABI is the input ABI used to generate the binding from.
@@ -798,16 +798,16 @@ func (_Contract *ContractCallerSession) DailySnapshotQuota(dataMarket common.Add
 
 // DataMarketCount is a free data retrieval call binding the contract method 0xef829a3d.
 //
-// Solidity: function dataMarketCount() view returns(uint8)
-func (_Contract *ContractCaller) DataMarketCount(opts *bind.CallOpts) (uint8, error) {
+// Solidity: function dataMarketCount() view returns(uint256)
+func (_Contract *ContractCaller) DataMarketCount(opts *bind.CallOpts) (*big.Int, error) {
 	var out []interface{}
 	err := _Contract.contract.Call(opts, &out, "dataMarketCount")
 
 	if err != nil {
-		return *new(uint8), err
+		return *new(*big.Int), err
 	}
 
-	out0 := *abi.ConvertType(out[0], new(uint8)).(*uint8)
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
 
 	return out0, err
 
@@ -815,15 +815,15 @@ func (_Contract *ContractCaller) DataMarketCount(opts *bind.CallOpts) (uint8, er
 
 // DataMarketCount is a free data retrieval call binding the contract method 0xef829a3d.
 //
-// Solidity: function dataMarketCount() view returns(uint8)
-func (_Contract *ContractSession) DataMarketCount() (uint8, error) {
+// Solidity: function dataMarketCount() view returns(uint256)
+func (_Contract *ContractSession) DataMarketCount() (*big.Int, error) {
 	return _Contract.Contract.DataMarketCount(&_Contract.CallOpts)
 }
 
 // DataMarketCount is a free data retrieval call binding the contract method 0xef829a3d.
 //
-// Solidity: function dataMarketCount() view returns(uint8)
-func (_Contract *ContractCallerSession) DataMarketCount() (uint8, error) {
+// Solidity: function dataMarketCount() view returns(uint256)
+func (_Contract *ContractCallerSession) DataMarketCount() (*big.Int, error) {
 	return _Contract.Contract.DataMarketCount(&_Contract.CallOpts)
 }
 
@@ -889,10 +889,10 @@ func (_Contract *ContractCallerSession) DataMarketFactory() (common.Address, err
 	return _Contract.Contract.DataMarketFactory(&_Contract.CallOpts)
 }
 
-// DataMarketIdToAddress is a free data retrieval call binding the contract method 0x0857b13f.
+// DataMarketIdToAddress is a free data retrieval call binding the contract method 0x1d9fea03.
 //
-// Solidity: function dataMarketIdToAddress(uint8 dataMarketId) view returns(address dataMarketAddress)
-func (_Contract *ContractCaller) DataMarketIdToAddress(opts *bind.CallOpts, dataMarketId uint8) (common.Address, error) {
+// Solidity: function dataMarketIdToAddress(uint256 dataMarketId) view returns(address dataMarketAddress)
+func (_Contract *ContractCaller) DataMarketIdToAddress(opts *bind.CallOpts, dataMarketId *big.Int) (common.Address, error) {
 	var out []interface{}
 	err := _Contract.contract.Call(opts, &out, "dataMarketIdToAddress", dataMarketId)
 
@@ -906,17 +906,17 @@ func (_Contract *ContractCaller) DataMarketIdToAddress(opts *bind.CallOpts, data
 
 }
 
-// DataMarketIdToAddress is a free data retrieval call binding the contract method 0x0857b13f.
+// DataMarketIdToAddress is a free data retrieval call binding the contract method 0x1d9fea03.
 //
-// Solidity: function dataMarketIdToAddress(uint8 dataMarketId) view returns(address dataMarketAddress)
-func (_Contract *ContractSession) DataMarketIdToAddress(dataMarketId uint8) (common.Address, error) {
+// Solidity: function dataMarketIdToAddress(uint256 dataMarketId) view returns(address dataMarketAddress)
+func (_Contract *ContractSession) DataMarketIdToAddress(dataMarketId *big.Int) (common.Address, error) {
 	return _Contract.Contract.DataMarketIdToAddress(&_Contract.CallOpts, dataMarketId)
 }
 
-// DataMarketIdToAddress is a free data retrieval call binding the contract method 0x0857b13f.
+// DataMarketIdToAddress is a free data retrieval call binding the contract method 0x1d9fea03.
 //
-// Solidity: function dataMarketIdToAddress(uint8 dataMarketId) view returns(address dataMarketAddress)
-func (_Contract *ContractCallerSession) DataMarketIdToAddress(dataMarketId uint8) (common.Address, error) {
+// Solidity: function dataMarketIdToAddress(uint256 dataMarketId) view returns(address dataMarketAddress)
+func (_Contract *ContractCallerSession) DataMarketIdToAddress(dataMarketId *big.Int) (common.Address, error) {
 	return _Contract.Contract.DataMarketIdToAddress(&_Contract.CallOpts, dataMarketId)
 }
 
@@ -1667,32 +1667,33 @@ func (_Contract *ContractCallerSession) MaxAttestationsCount(dataMarket common.A
 
 // MaxSnapshotsCid is a free data retrieval call binding the contract method 0x7e9ce892.
 //
-// Solidity: function maxSnapshotsCid(address dataMarket, string projectId, uint256 epochId) view returns(string)
-func (_Contract *ContractCaller) MaxSnapshotsCid(opts *bind.CallOpts, dataMarket common.Address, projectId string, epochId *big.Int) (string, error) {
+// Solidity: function maxSnapshotsCid(address dataMarket, string projectId, uint256 epochId) view returns(string, uint8)
+func (_Contract *ContractCaller) MaxSnapshotsCid(opts *bind.CallOpts, dataMarket common.Address, projectId string, epochId *big.Int) (string, uint8, error) {
 	var out []interface{}
 	err := _Contract.contract.Call(opts, &out, "maxSnapshotsCid", dataMarket, projectId, epochId)
 
 	if err != nil {
-		return *new(string), err
+		return *new(string), *new(uint8), err
 	}
 
 	out0 := *abi.ConvertType(out[0], new(string)).(*string)
+	out1 := *abi.ConvertType(out[1], new(uint8)).(*uint8)
 
-	return out0, err
+	return out0, out1, err
 
 }
 
 // MaxSnapshotsCid is a free data retrieval call binding the contract method 0x7e9ce892.
 //
-// Solidity: function maxSnapshotsCid(address dataMarket, string projectId, uint256 epochId) view returns(string)
-func (_Contract *ContractSession) MaxSnapshotsCid(dataMarket common.Address, projectId string, epochId *big.Int) (string, error) {
+// Solidity: function maxSnapshotsCid(address dataMarket, string projectId, uint256 epochId) view returns(string, uint8)
+func (_Contract *ContractSession) MaxSnapshotsCid(dataMarket common.Address, projectId string, epochId *big.Int) (string, uint8, error) {
 	return _Contract.Contract.MaxSnapshotsCid(&_Contract.CallOpts, dataMarket, projectId, epochId)
 }
 
 // MaxSnapshotsCid is a free data retrieval call binding the contract method 0x7e9ce892.
 //
-// Solidity: function maxSnapshotsCid(address dataMarket, string projectId, uint256 epochId) view returns(string)
-func (_Contract *ContractCallerSession) MaxSnapshotsCid(dataMarket common.Address, projectId string, epochId *big.Int) (string, error) {
+// Solidity: function maxSnapshotsCid(address dataMarket, string projectId, uint256 epochId) view returns(string, uint8)
+func (_Contract *ContractCallerSession) MaxSnapshotsCid(dataMarket common.Address, projectId string, epochId *big.Int) (string, uint8, error) {
 	return _Contract.Contract.MaxSnapshotsCid(&_Contract.CallOpts, dataMarket, projectId, epochId)
 }
 
@@ -1756,6 +1757,37 @@ func (_Contract *ContractSession) Owner() (common.Address, error) {
 // Solidity: function owner() view returns(address)
 func (_Contract *ContractCallerSession) Owner() (common.Address, error) {
 	return _Contract.Contract.Owner(&_Contract.CallOpts)
+}
+
+// PendingOwner is a free data retrieval call binding the contract method 0xe30c3978.
+//
+// Solidity: function pendingOwner() view returns(address)
+func (_Contract *ContractCaller) PendingOwner(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _Contract.contract.Call(opts, &out, "pendingOwner")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// PendingOwner is a free data retrieval call binding the contract method 0xe30c3978.
+//
+// Solidity: function pendingOwner() view returns(address)
+func (_Contract *ContractSession) PendingOwner() (common.Address, error) {
+	return _Contract.Contract.PendingOwner(&_Contract.CallOpts)
+}
+
+// PendingOwner is a free data retrieval call binding the contract method 0xe30c3978.
+//
+// Solidity: function pendingOwner() view returns(address)
+func (_Contract *ContractCallerSession) PendingOwner() (common.Address, error) {
+	return _Contract.Contract.PendingOwner(&_Contract.CallOpts)
 }
 
 // ProjectFirstEpochId is a free data retrieval call binding the contract method 0x4242614c.
@@ -2173,6 +2205,27 @@ func (_Contract *ContractCallerSession) UserInfo(arg0 common.Address) (struct {
 	return _Contract.Contract.UserInfo(&_Contract.CallOpts, arg0)
 }
 
+// AcceptOwnership is a paid mutator transaction binding the contract method 0x79ba5097.
+//
+// Solidity: function acceptOwnership() returns()
+func (_Contract *ContractTransactor) AcceptOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Contract.contract.Transact(opts, "acceptOwnership")
+}
+
+// AcceptOwnership is a paid mutator transaction binding the contract method 0x79ba5097.
+//
+// Solidity: function acceptOwnership() returns()
+func (_Contract *ContractSession) AcceptOwnership() (*types.Transaction, error) {
+	return _Contract.Contract.AcceptOwnership(&_Contract.TransactOpts)
+}
+
+// AcceptOwnership is a paid mutator transaction binding the contract method 0x79ba5097.
+//
+// Solidity: function acceptOwnership() returns()
+func (_Contract *ContractTransactorSession) AcceptOwnership() (*types.Transaction, error) {
+	return _Contract.Contract.AcceptOwnership(&_Contract.TransactOpts)
+}
+
 // ClaimRewards is a paid mutator transaction binding the contract method 0xef5cfb8c.
 //
 // Solidity: function claimRewards(address _user) returns()
@@ -2299,25 +2352,25 @@ func (_Contract *ContractTransactorSession) ForceSkipEpoch(dataMarket common.Add
 	return _Contract.Contract.ForceSkipEpoch(&_Contract.TransactOpts, dataMarket, begin, end)
 }
 
-// Initialize is a paid mutator transaction binding the contract method 0xc4d66de8.
+// Initialize is a paid mutator transaction binding the contract method 0xc0c53b8b.
 //
-// Solidity: function initialize(address initialOwner) returns()
-func (_Contract *ContractTransactor) Initialize(opts *bind.TransactOpts, initialOwner common.Address) (*types.Transaction, error) {
-	return _Contract.contract.Transact(opts, "initialize", initialOwner)
+// Solidity: function initialize(address initialOwner, address _snapshotterState, address _dataMarketFactory) returns()
+func (_Contract *ContractTransactor) Initialize(opts *bind.TransactOpts, initialOwner common.Address, _snapshotterState common.Address, _dataMarketFactory common.Address) (*types.Transaction, error) {
+	return _Contract.contract.Transact(opts, "initialize", initialOwner, _snapshotterState, _dataMarketFactory)
 }
 
-// Initialize is a paid mutator transaction binding the contract method 0xc4d66de8.
+// Initialize is a paid mutator transaction binding the contract method 0xc0c53b8b.
 //
-// Solidity: function initialize(address initialOwner) returns()
-func (_Contract *ContractSession) Initialize(initialOwner common.Address) (*types.Transaction, error) {
-	return _Contract.Contract.Initialize(&_Contract.TransactOpts, initialOwner)
+// Solidity: function initialize(address initialOwner, address _snapshotterState, address _dataMarketFactory) returns()
+func (_Contract *ContractSession) Initialize(initialOwner common.Address, _snapshotterState common.Address, _dataMarketFactory common.Address) (*types.Transaction, error) {
+	return _Contract.Contract.Initialize(&_Contract.TransactOpts, initialOwner, _snapshotterState, _dataMarketFactory)
 }
 
-// Initialize is a paid mutator transaction binding the contract method 0xc4d66de8.
+// Initialize is a paid mutator transaction binding the contract method 0xc0c53b8b.
 //
-// Solidity: function initialize(address initialOwner) returns()
-func (_Contract *ContractTransactorSession) Initialize(initialOwner common.Address) (*types.Transaction, error) {
-	return _Contract.Contract.Initialize(&_Contract.TransactOpts, initialOwner)
+// Solidity: function initialize(address initialOwner, address _snapshotterState, address _dataMarketFactory) returns()
+func (_Contract *ContractTransactorSession) Initialize(initialOwner common.Address, _snapshotterState common.Address, _dataMarketFactory common.Address) (*types.Transaction, error) {
+	return _Contract.Contract.Initialize(&_Contract.TransactOpts, initialOwner, _snapshotterState, _dataMarketFactory)
 }
 
 // LoadCurrentDay is a paid mutator transaction binding the contract method 0x59c60b30.
@@ -2635,27 +2688,6 @@ func (_Contract *ContractTransactorSession) UpdateDataMarketFactory(_address com
 	return _Contract.Contract.UpdateDataMarketFactory(&_Contract.TransactOpts, _address)
 }
 
-// UpdateDaySize is a paid mutator transaction binding the contract method 0x79145b89.
-//
-// Solidity: function updateDaySize(address dataMarket, uint256 newDaySize) returns()
-func (_Contract *ContractTransactor) UpdateDaySize(opts *bind.TransactOpts, dataMarket common.Address, newDaySize *big.Int) (*types.Transaction, error) {
-	return _Contract.contract.Transact(opts, "updateDaySize", dataMarket, newDaySize)
-}
-
-// UpdateDaySize is a paid mutator transaction binding the contract method 0x79145b89.
-//
-// Solidity: function updateDaySize(address dataMarket, uint256 newDaySize) returns()
-func (_Contract *ContractSession) UpdateDaySize(dataMarket common.Address, newDaySize *big.Int) (*types.Transaction, error) {
-	return _Contract.Contract.UpdateDaySize(&_Contract.TransactOpts, dataMarket, newDaySize)
-}
-
-// UpdateDaySize is a paid mutator transaction binding the contract method 0x79145b89.
-//
-// Solidity: function updateDaySize(address dataMarket, uint256 newDaySize) returns()
-func (_Contract *ContractTransactorSession) UpdateDaySize(dataMarket common.Address, newDaySize *big.Int) (*types.Transaction, error) {
-	return _Contract.Contract.UpdateDaySize(&_Contract.TransactOpts, dataMarket, newDaySize)
-}
-
 // UpdateEpochManager is a paid mutator transaction binding the contract method 0x6e81f234.
 //
 // Solidity: function updateEpochManager(address dataMarket, address _address) returns()
@@ -2801,6 +2833,27 @@ func (_Contract *ContractSession) UpgradeToAndCall(newImplementation common.Addr
 // Solidity: function upgradeToAndCall(address newImplementation, bytes data) payable returns()
 func (_Contract *ContractTransactorSession) UpgradeToAndCall(newImplementation common.Address, data []byte) (*types.Transaction, error) {
 	return _Contract.Contract.UpgradeToAndCall(&_Contract.TransactOpts, newImplementation, data)
+}
+
+// Receive is a paid mutator transaction binding the contract receive function.
+//
+// Solidity: receive() payable returns()
+func (_Contract *ContractTransactor) Receive(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Contract.contract.RawTransact(opts, nil) // calldata is disallowed for receive function
+}
+
+// Receive is a paid mutator transaction binding the contract receive function.
+//
+// Solidity: receive() payable returns()
+func (_Contract *ContractSession) Receive() (*types.Transaction, error) {
+	return _Contract.Contract.Receive(&_Contract.TransactOpts)
+}
+
+// Receive is a paid mutator transaction binding the contract receive function.
+//
+// Solidity: receive() payable returns()
+func (_Contract *ContractTransactorSession) Receive() (*types.Transaction, error) {
+	return _Contract.Contract.Receive(&_Contract.TransactOpts)
 }
 
 // ContractAdminsUpdatedIterator is returned from FilterAdminsUpdated and is used to iterate over the raw logs and unpacked data for AdminsUpdated events raised by the Contract contract.
@@ -3176,14 +3229,13 @@ type ContractDailyTaskCompletedEvent struct {
 	SnapshotterAddress common.Address
 	SlotId             *big.Int
 	DayId              *big.Int
-	RewardPoints       *big.Int
 	Timestamp          *big.Int
 	Raw                types.Log // Blockchain specific contextual infos
 }
 
-// FilterDailyTaskCompletedEvent is a free log retrieval operation binding the contract event 0x3f80954353f9060121cb024ef2580d122fc250f7faad898ef5167aeef38f2b12.
+// FilterDailyTaskCompletedEvent is a free log retrieval operation binding the contract event 0x7da483c8dd175f1c370a23b17545e19c0584cf3960d991202e216e6cf95b7a3d.
 //
-// Solidity: event DailyTaskCompletedEvent(address indexed dataMarketAddress, address snapshotterAddress, uint256 slotId, uint256 dayId, uint256 rewardPoints, uint256 timestamp)
+// Solidity: event DailyTaskCompletedEvent(address indexed dataMarketAddress, address snapshotterAddress, uint256 slotId, uint256 dayId, uint256 timestamp)
 func (_Contract *ContractFilterer) FilterDailyTaskCompletedEvent(opts *bind.FilterOpts, dataMarketAddress []common.Address) (*ContractDailyTaskCompletedEventIterator, error) {
 
 	var dataMarketAddressRule []interface{}
@@ -3198,9 +3250,9 @@ func (_Contract *ContractFilterer) FilterDailyTaskCompletedEvent(opts *bind.Filt
 	return &ContractDailyTaskCompletedEventIterator{contract: _Contract.contract, event: "DailyTaskCompletedEvent", logs: logs, sub: sub}, nil
 }
 
-// WatchDailyTaskCompletedEvent is a free log subscription operation binding the contract event 0x3f80954353f9060121cb024ef2580d122fc250f7faad898ef5167aeef38f2b12.
+// WatchDailyTaskCompletedEvent is a free log subscription operation binding the contract event 0x7da483c8dd175f1c370a23b17545e19c0584cf3960d991202e216e6cf95b7a3d.
 //
-// Solidity: event DailyTaskCompletedEvent(address indexed dataMarketAddress, address snapshotterAddress, uint256 slotId, uint256 dayId, uint256 rewardPoints, uint256 timestamp)
+// Solidity: event DailyTaskCompletedEvent(address indexed dataMarketAddress, address snapshotterAddress, uint256 slotId, uint256 dayId, uint256 timestamp)
 func (_Contract *ContractFilterer) WatchDailyTaskCompletedEvent(opts *bind.WatchOpts, sink chan<- *ContractDailyTaskCompletedEvent, dataMarketAddress []common.Address) (event.Subscription, error) {
 
 	var dataMarketAddressRule []interface{}
@@ -3240,9 +3292,9 @@ func (_Contract *ContractFilterer) WatchDailyTaskCompletedEvent(opts *bind.Watch
 	}), nil
 }
 
-// ParseDailyTaskCompletedEvent is a log parse operation binding the contract event 0x3f80954353f9060121cb024ef2580d122fc250f7faad898ef5167aeef38f2b12.
+// ParseDailyTaskCompletedEvent is a log parse operation binding the contract event 0x7da483c8dd175f1c370a23b17545e19c0584cf3960d991202e216e6cf95b7a3d.
 //
-// Solidity: event DailyTaskCompletedEvent(address indexed dataMarketAddress, address snapshotterAddress, uint256 slotId, uint256 dayId, uint256 rewardPoints, uint256 timestamp)
+// Solidity: event DailyTaskCompletedEvent(address indexed dataMarketAddress, address snapshotterAddress, uint256 slotId, uint256 dayId, uint256 timestamp)
 func (_Contract *ContractFilterer) ParseDailyTaskCompletedEvent(log types.Log) (*ContractDailyTaskCompletedEvent, error) {
 	event := new(ContractDailyTaskCompletedEvent)
 	if err := _Contract.contract.UnpackLog(event, "DailyTaskCompletedEvent", log); err != nil {
@@ -4476,6 +4528,159 @@ func (_Contract *ContractFilterer) ParseInitialized(log types.Log) (*ContractIni
 	return event, nil
 }
 
+// ContractOwnershipTransferStartedIterator is returned from FilterOwnershipTransferStarted and is used to iterate over the raw logs and unpacked data for OwnershipTransferStarted events raised by the Contract contract.
+type ContractOwnershipTransferStartedIterator struct {
+	Event *ContractOwnershipTransferStarted // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *ContractOwnershipTransferStartedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(ContractOwnershipTransferStarted)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(ContractOwnershipTransferStarted)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *ContractOwnershipTransferStartedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *ContractOwnershipTransferStartedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// ContractOwnershipTransferStarted represents a OwnershipTransferStarted event raised by the Contract contract.
+type ContractOwnershipTransferStarted struct {
+	PreviousOwner common.Address
+	NewOwner      common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnershipTransferStarted is a free log retrieval operation binding the contract event 0x38d16b8cac22d99fc7c124b9cd0de2d3fa1faef420bfe791d8c362d765e22700.
+//
+// Solidity: event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
+func (_Contract *ContractFilterer) FilterOwnershipTransferStarted(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*ContractOwnershipTransferStartedIterator, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _Contract.contract.FilterLogs(opts, "OwnershipTransferStarted", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &ContractOwnershipTransferStartedIterator{contract: _Contract.contract, event: "OwnershipTransferStarted", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnershipTransferStarted is a free log subscription operation binding the contract event 0x38d16b8cac22d99fc7c124b9cd0de2d3fa1faef420bfe791d8c362d765e22700.
+//
+// Solidity: event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
+func (_Contract *ContractFilterer) WatchOwnershipTransferStarted(opts *bind.WatchOpts, sink chan<- *ContractOwnershipTransferStarted, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _Contract.contract.WatchLogs(opts, "OwnershipTransferStarted", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(ContractOwnershipTransferStarted)
+				if err := _Contract.contract.UnpackLog(event, "OwnershipTransferStarted", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOwnershipTransferStarted is a log parse operation binding the contract event 0x38d16b8cac22d99fc7c124b9cd0de2d3fa1faef420bfe791d8c362d765e22700.
+//
+// Solidity: event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
+func (_Contract *ContractFilterer) ParseOwnershipTransferStarted(log types.Log) (*ContractOwnershipTransferStarted, error) {
+	event := new(ContractOwnershipTransferStarted)
+	if err := _Contract.contract.UnpackLog(event, "OwnershipTransferStarted", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
 // ContractOwnershipTransferredIterator is returned from FilterOwnershipTransferred and is used to iterate over the raw logs and unpacked data for OwnershipTransferred events raised by the Contract contract.
 type ContractOwnershipTransferredIterator struct {
 	Event *ContractOwnershipTransferred // Event containing the contract specifics and raw log
@@ -4769,6 +4974,155 @@ func (_Contract *ContractFilterer) WatchRewardsClaimed(opts *bind.WatchOpts, sin
 func (_Contract *ContractFilterer) ParseRewardsClaimed(log types.Log) (*ContractRewardsClaimed, error) {
 	event := new(ContractRewardsClaimed)
 	if err := _Contract.contract.UnpackLog(event, "RewardsClaimed", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// ContractRewardsDistributedEventIterator is returned from FilterRewardsDistributedEvent and is used to iterate over the raw logs and unpacked data for RewardsDistributedEvent events raised by the Contract contract.
+type ContractRewardsDistributedEventIterator struct {
+	Event *ContractRewardsDistributedEvent // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *ContractRewardsDistributedEventIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(ContractRewardsDistributedEvent)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(ContractRewardsDistributedEvent)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *ContractRewardsDistributedEventIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *ContractRewardsDistributedEventIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// ContractRewardsDistributedEvent represents a RewardsDistributedEvent event raised by the Contract contract.
+type ContractRewardsDistributedEvent struct {
+	DataMarketAddress  common.Address
+	SnapshotterAddress common.Address
+	SlotId             *big.Int
+	DayId              *big.Int
+	RewardPoints       *big.Int
+	Timestamp          *big.Int
+	Raw                types.Log // Blockchain specific contextual infos
+}
+
+// FilterRewardsDistributedEvent is a free log retrieval operation binding the contract event 0xff2541745d6ce75b9522a6e9b397f0c46d824c46a8bd4c145797d01f770dcf78.
+//
+// Solidity: event RewardsDistributedEvent(address indexed dataMarketAddress, address snapshotterAddress, uint256 slotId, uint256 dayId, uint256 rewardPoints, uint256 timestamp)
+func (_Contract *ContractFilterer) FilterRewardsDistributedEvent(opts *bind.FilterOpts, dataMarketAddress []common.Address) (*ContractRewardsDistributedEventIterator, error) {
+
+	var dataMarketAddressRule []interface{}
+	for _, dataMarketAddressItem := range dataMarketAddress {
+		dataMarketAddressRule = append(dataMarketAddressRule, dataMarketAddressItem)
+	}
+
+	logs, sub, err := _Contract.contract.FilterLogs(opts, "RewardsDistributedEvent", dataMarketAddressRule)
+	if err != nil {
+		return nil, err
+	}
+	return &ContractRewardsDistributedEventIterator{contract: _Contract.contract, event: "RewardsDistributedEvent", logs: logs, sub: sub}, nil
+}
+
+// WatchRewardsDistributedEvent is a free log subscription operation binding the contract event 0xff2541745d6ce75b9522a6e9b397f0c46d824c46a8bd4c145797d01f770dcf78.
+//
+// Solidity: event RewardsDistributedEvent(address indexed dataMarketAddress, address snapshotterAddress, uint256 slotId, uint256 dayId, uint256 rewardPoints, uint256 timestamp)
+func (_Contract *ContractFilterer) WatchRewardsDistributedEvent(opts *bind.WatchOpts, sink chan<- *ContractRewardsDistributedEvent, dataMarketAddress []common.Address) (event.Subscription, error) {
+
+	var dataMarketAddressRule []interface{}
+	for _, dataMarketAddressItem := range dataMarketAddress {
+		dataMarketAddressRule = append(dataMarketAddressRule, dataMarketAddressItem)
+	}
+
+	logs, sub, err := _Contract.contract.WatchLogs(opts, "RewardsDistributedEvent", dataMarketAddressRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(ContractRewardsDistributedEvent)
+				if err := _Contract.contract.UnpackLog(event, "RewardsDistributedEvent", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRewardsDistributedEvent is a log parse operation binding the contract event 0xff2541745d6ce75b9522a6e9b397f0c46d824c46a8bd4c145797d01f770dcf78.
+//
+// Solidity: event RewardsDistributedEvent(address indexed dataMarketAddress, address snapshotterAddress, uint256 slotId, uint256 dayId, uint256 rewardPoints, uint256 timestamp)
+func (_Contract *ContractFilterer) ParseRewardsDistributedEvent(log types.Log) (*ContractRewardsDistributedEvent, error) {
+	event := new(ContractRewardsDistributedEvent)
+	if err := _Contract.contract.UnpackLog(event, "RewardsDistributedEvent", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log

--- a/pkgs/prost/processor.go
+++ b/pkgs/prost/processor.go
@@ -7,11 +7,12 @@ import (
 	"math/big"
 	"protocol-state-cacher/config"
 	"protocol-state-cacher/pkgs"
-	"protocol-state-cacher/pkgs/contract"
 	"protocol-state-cacher/pkgs/redis"
 	"protocol-state-cacher/pkgs/reporting"
 	"strings"
 	"time"
+
+	"strconv"
 
 	"github.com/cenkalti/backoff"
 	"github.com/ethereum/go-ethereum"
@@ -218,35 +219,36 @@ func ProcessSnapshotterStateEvents(block *types.Block) {
 
 				// Process the node ID and snapshotter address
 				log.Infof("🚀 Node ID: %d, Snapshotter Address: %s", nodeID, snapshotterAddress.Hex())
-				addSlotInfo(dataMarketAddress, nodeID)
+				addSlotInfo(nodeID)
 			}
 		}
 	}
 }
 
-func addSlotInfo(dataMarketAddress string, slotID int64) {
+func addSlotInfo(slotID int64) {
 	// Fetch the slot info from the contract
-	slot, err := Instance.GetSlotInfo(&bind.CallOpts{}, common.HexToAddress(dataMarketAddress), big.NewInt(slotID))
+	slot, err := SnapshotterStateInstance.NodeInfo(&bind.CallOpts{}, big.NewInt(slotID))
 	if err != nil {
-		log.Printf("Error fetching slot %d for data market %s: %v", slotID, dataMarketAddress, err)
+		log.Printf("Error fetching slot %d: %v", slotID, err)
 		return
 	}
 
-	// Check if the slot info is empty
-	if slot == (contract.PowerloomDataMarketSlotInfo{}) {
-		log.Printf("No data for slot %d in data market %s", slotID, dataMarketAddress)
+	// Check if the slot info is empty by checking the address field
+	// TODO: Is this needed here? Slot could be minted without an assigned address, but we only use the address for now
+	if slot.SnapshotterAddress == (common.Address{}) {
+		log.Printf("No snapshotter address for slot %d", slotID)
 		return
 	}
 
 	// Marshal the slot info to JSON
 	slotMarshalled, err := json.Marshal(slot)
 	if err != nil {
-		log.Printf("Error marshalling slot %d for data market %s: %v", slotID, dataMarketAddress, err)
+		log.Printf("Error marshalling slot %d: %v", slotID, err)
 		return
 	}
 
 	// Persist slot information
-	slotKey := redis.SlotInfo(slot.SlotId.String())
+	slotKey := redis.SlotInfo(strconv.FormatInt(slotID, 10))
 	PersistState(context.Background(), slotKey, string(slotMarshalled))
 
 	// Add slot key to the batch
@@ -254,7 +256,7 @@ func addSlotInfo(dataMarketAddress string, slotID int64) {
 	allSlots = append(allSlots, slotKey)
 	mu.Unlock()
 
-	log.Printf("Fetched and persisted slot %d for data market %s", slotID, dataMarketAddress)
+	log.Printf("Fetched and persisted slot %d", slotID)
 }
 
 func decodeTransactionInput(inputData []byte) (int64, common.Address, error) {

--- a/pkgs/snapshotterStateContract/abi.json
+++ b/pkgs/snapshotterStateContract/abi.json
@@ -6,124 +6,124 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "address",
-                "name": "target",
-                "type": "address"
-            }
+        {
+            "internalType": "address",
+            "name": "target",
+            "type": "address"
+        }
         ],
         "name": "AddressEmptyCode",
         "type": "error"
     },
     {
         "inputs": [
-            {
-                "internalType": "address",
-                "name": "sender",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "balance",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "needed",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "tokenId",
-                "type": "uint256"
-            }
+        {
+            "internalType": "address",
+            "name": "sender",
+            "type": "address"
+        },
+        {
+            "internalType": "uint256",
+            "name": "balance",
+            "type": "uint256"
+        },
+        {
+            "internalType": "uint256",
+            "name": "needed",
+            "type": "uint256"
+        },
+        {
+            "internalType": "uint256",
+            "name": "tokenId",
+            "type": "uint256"
+        }
         ],
         "name": "ERC1155InsufficientBalance",
         "type": "error"
     },
     {
         "inputs": [
-            {
-                "internalType": "address",
-                "name": "approver",
-                "type": "address"
-            }
+        {
+            "internalType": "address",
+            "name": "approver",
+            "type": "address"
+        }
         ],
         "name": "ERC1155InvalidApprover",
         "type": "error"
     },
     {
         "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "idsLength",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "valuesLength",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "idsLength",
+            "type": "uint256"
+        },
+        {
+            "internalType": "uint256",
+            "name": "valuesLength",
+            "type": "uint256"
+        }
         ],
         "name": "ERC1155InvalidArrayLength",
         "type": "error"
     },
     {
         "inputs": [
-            {
-                "internalType": "address",
-                "name": "operator",
-                "type": "address"
-            }
+        {
+            "internalType": "address",
+            "name": "operator",
+            "type": "address"
+        }
         ],
         "name": "ERC1155InvalidOperator",
         "type": "error"
     },
     {
         "inputs": [
-            {
-                "internalType": "address",
-                "name": "receiver",
-                "type": "address"
-            }
+        {
+            "internalType": "address",
+            "name": "receiver",
+            "type": "address"
+        }
         ],
         "name": "ERC1155InvalidReceiver",
         "type": "error"
     },
     {
         "inputs": [
-            {
-                "internalType": "address",
-                "name": "sender",
-                "type": "address"
-            }
+        {
+            "internalType": "address",
+            "name": "sender",
+            "type": "address"
+        }
         ],
         "name": "ERC1155InvalidSender",
         "type": "error"
     },
     {
         "inputs": [
-            {
-                "internalType": "address",
-                "name": "operator",
-                "type": "address"
-            },
-            {
-                "internalType": "address",
-                "name": "owner",
-                "type": "address"
-            }
+        {
+            "internalType": "address",
+            "name": "operator",
+            "type": "address"
+        },
+        {
+            "internalType": "address",
+            "name": "owner",
+            "type": "address"
+        }
         ],
         "name": "ERC1155MissingApprovalForAll",
         "type": "error"
     },
     {
         "inputs": [
-            {
-                "internalType": "address",
-                "name": "implementation",
-                "type": "address"
-            }
+        {
+            "internalType": "address",
+            "name": "implementation",
+            "type": "address"
+        }
         ],
         "name": "ERC1967InvalidImplementation",
         "type": "error"
@@ -160,22 +160,22 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "address",
-                "name": "owner",
-                "type": "address"
-            }
+        {
+            "internalType": "address",
+            "name": "owner",
+            "type": "address"
+        }
         ],
         "name": "OwnableInvalidOwner",
         "type": "error"
     },
     {
         "inputs": [
-            {
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            }
+        {
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+        }
         ],
         "name": "OwnableUnauthorizedAccount",
         "type": "error"
@@ -192,11 +192,11 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "bytes32",
-                "name": "slot",
-                "type": "bytes32"
-            }
+        {
+            "internalType": "bytes32",
+            "name": "slot",
+            "type": "bytes32"
+        }
         ],
         "name": "UUPSUnsupportedProxiableUUID",
         "type": "error"
@@ -204,18 +204,18 @@
     {
         "anonymous": false,
         "inputs": [
-            {
-                "indexed": false,
-                "internalType": "address",
-                "name": "adminAddress",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "bool",
-                "name": "allowed",
-                "type": "bool"
-            }
+        {
+            "indexed": false,
+            "internalType": "address",
+            "name": "adminAddress",
+            "type": "address"
+        },
+        {
+            "indexed": false,
+            "internalType": "bool",
+            "name": "allowed",
+            "type": "bool"
+        }
         ],
         "name": "AdminsUpdated",
         "type": "event"
@@ -223,24 +223,24 @@
     {
         "anonymous": false,
         "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "operator",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "bool",
-                "name": "approved",
-                "type": "bool"
-            }
+        {
+            "indexed": true,
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+        },
+        {
+            "indexed": true,
+            "internalType": "address",
+            "name": "operator",
+            "type": "address"
+        },
+        {
+            "indexed": false,
+            "internalType": "bool",
+            "name": "approved",
+            "type": "bool"
+        }
         ],
         "name": "ApprovalForAll",
         "type": "event"
@@ -248,18 +248,18 @@
     {
         "anonymous": false,
         "inputs": [
-            {
-                "indexed": false,
-                "internalType": "string",
-                "name": "paramName",
-                "type": "string"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "newValue",
-                "type": "uint256"
-            }
+        {
+            "indexed": false,
+            "internalType": "string",
+            "name": "paramName",
+            "type": "string"
+        },
+        {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "newValue",
+            "type": "uint256"
+        }
         ],
         "name": "ConfigurationUpdated",
         "type": "event"
@@ -267,18 +267,18 @@
     {
         "anonymous": false,
         "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "from",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            }
+        {
+            "indexed": true,
+            "internalType": "address",
+            "name": "from",
+            "type": "address"
+        },
+        {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+        }
         ],
         "name": "Deposit",
         "type": "event"
@@ -286,18 +286,18 @@
     {
         "anonymous": false,
         "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "owner",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            }
+        {
+            "indexed": true,
+            "internalType": "address",
+            "name": "owner",
+            "type": "address"
+        },
+        {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+        }
         ],
         "name": "EmergencyWithdraw",
         "type": "event"
@@ -305,12 +305,12 @@
     {
         "anonymous": false,
         "inputs": [
-            {
-                "indexed": false,
-                "internalType": "uint64",
-                "name": "version",
-                "type": "uint64"
-            }
+        {
+            "indexed": false,
+            "internalType": "uint64",
+            "name": "version",
+            "type": "uint64"
+        }
         ],
         "name": "Initialized",
         "type": "event"
@@ -318,24 +318,24 @@
     {
         "anonymous": false,
         "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "claimer",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "nodeId",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            }
+        {
+            "indexed": true,
+            "internalType": "address",
+            "name": "claimer",
+            "type": "address"
+        },
+        {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "nodeId",
+            "type": "uint256"
+        },
+        {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+        }
         ],
         "name": "LegacyNodeTokensClaimed",
         "type": "event"
@@ -343,12 +343,12 @@
     {
         "anonymous": false,
         "inputs": [
-            {
-                "indexed": false,
-                "internalType": "string",
-                "name": "newName",
-                "type": "string"
-            }
+        {
+            "indexed": false,
+            "internalType": "string",
+            "name": "newName",
+            "type": "string"
+        }
         ],
         "name": "NameUpdated",
         "type": "event"
@@ -356,18 +356,18 @@
     {
         "anonymous": false,
         "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "from",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "nodeId",
-                "type": "uint256"
-            }
+        {
+            "indexed": true,
+            "internalType": "address",
+            "name": "from",
+            "type": "address"
+        },
+        {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "nodeId",
+            "type": "uint256"
+        }
         ],
         "name": "NodeBurned",
         "type": "event"
@@ -375,18 +375,18 @@
     {
         "anonymous": false,
         "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "to",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "nodeId",
-                "type": "uint256"
-            }
+        {
+            "indexed": true,
+            "internalType": "address",
+            "name": "to",
+            "type": "address"
+        },
+        {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "nodeId",
+            "type": "uint256"
+        }
         ],
         "name": "NodeMinted",
         "type": "event"
@@ -394,18 +394,37 @@
     {
         "anonymous": false,
         "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "previousOwner",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "newOwner",
-                "type": "address"
-            }
+        {
+            "indexed": true,
+            "internalType": "address",
+            "name": "previousOwner",
+            "type": "address"
+        },
+        {
+            "indexed": true,
+            "internalType": "address",
+            "name": "newOwner",
+            "type": "address"
+        }
+        ],
+        "name": "OwnershipTransferStarted",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+        {
+            "indexed": true,
+            "internalType": "address",
+            "name": "previousOwner",
+            "type": "address"
+        },
+        {
+            "indexed": true,
+            "internalType": "address",
+            "name": "newOwner",
+            "type": "address"
+        }
         ],
         "name": "OwnershipTransferred",
         "type": "event"
@@ -413,12 +432,12 @@
     {
         "anonymous": false,
         "inputs": [
-            {
-                "indexed": false,
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            }
+        {
+            "indexed": false,
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+        }
         ],
         "name": "Paused",
         "type": "event"
@@ -426,12 +445,37 @@
     {
         "anonymous": false,
         "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "newSnapshotterState",
-                "type": "address"
-            }
+        {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "nodeId",
+            "type": "uint256"
+        },
+        {
+            "indexed": false,
+            "internalType": "address",
+            "name": "oldSnapshotter",
+            "type": "address"
+        },
+        {
+            "indexed": false,
+            "internalType": "address",
+            "name": "newSnapshotter",
+            "type": "address"
+        }
+        ],
+        "name": "SnapshotterAddressChanged",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+        {
+            "indexed": true,
+            "internalType": "address",
+            "name": "newSnapshotterState",
+            "type": "address"
+        }
         ],
         "name": "SnapshotterStateUpdated",
         "type": "event"
@@ -439,24 +483,24 @@
     {
         "anonymous": false,
         "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "claimer",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "nodeId",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            }
+        {
+            "indexed": true,
+            "internalType": "address",
+            "name": "claimer",
+            "type": "address"
+        },
+        {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "nodeId",
+            "type": "uint256"
+        },
+        {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+        }
         ],
         "name": "SnapshotterTokensClaimed",
         "type": "event"
@@ -464,36 +508,36 @@
     {
         "anonymous": false,
         "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "operator",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "from",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "to",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256[]",
-                "name": "ids",
-                "type": "uint256[]"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256[]",
-                "name": "values",
-                "type": "uint256[]"
-            }
+        {
+            "indexed": true,
+            "internalType": "address",
+            "name": "operator",
+            "type": "address"
+        },
+        {
+            "indexed": true,
+            "internalType": "address",
+            "name": "from",
+            "type": "address"
+        },
+        {
+            "indexed": true,
+            "internalType": "address",
+            "name": "to",
+            "type": "address"
+        },
+        {
+            "indexed": false,
+            "internalType": "uint256[]",
+            "name": "ids",
+            "type": "uint256[]"
+        },
+        {
+            "indexed": false,
+            "internalType": "uint256[]",
+            "name": "values",
+            "type": "uint256[]"
+        }
         ],
         "name": "TransferBatch",
         "type": "event"
@@ -501,36 +545,36 @@
     {
         "anonymous": false,
         "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "operator",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "from",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "to",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "id",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "value",
-                "type": "uint256"
-            }
+        {
+            "indexed": true,
+            "internalType": "address",
+            "name": "operator",
+            "type": "address"
+        },
+        {
+            "indexed": true,
+            "internalType": "address",
+            "name": "from",
+            "type": "address"
+        },
+        {
+            "indexed": true,
+            "internalType": "address",
+            "name": "to",
+            "type": "address"
+        },
+        {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "id",
+            "type": "uint256"
+        },
+        {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "value",
+            "type": "uint256"
+        }
         ],
         "name": "TransferSingle",
         "type": "event"
@@ -538,18 +582,18 @@
     {
         "anonymous": false,
         "inputs": [
-            {
-                "indexed": false,
-                "internalType": "string",
-                "name": "value",
-                "type": "string"
-            },
-            {
-                "indexed": true,
-                "internalType": "uint256",
-                "name": "id",
-                "type": "uint256"
-            }
+        {
+            "indexed": false,
+            "internalType": "string",
+            "name": "value",
+            "type": "string"
+        },
+        {
+            "indexed": true,
+            "internalType": "uint256",
+            "name": "id",
+            "type": "uint256"
+        }
         ],
         "name": "URI",
         "type": "event"
@@ -557,12 +601,12 @@
     {
         "anonymous": false,
         "inputs": [
-            {
-                "indexed": false,
-                "internalType": "string",
-                "name": "newUri",
-                "type": "string"
-            }
+        {
+            "indexed": false,
+            "internalType": "string",
+            "name": "newUri",
+            "type": "string"
+        }
         ],
         "name": "URIUpdated",
         "type": "event"
@@ -570,12 +614,12 @@
     {
         "anonymous": false,
         "inputs": [
-            {
-                "indexed": false,
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            }
+        {
+            "indexed": false,
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+        }
         ],
         "name": "Unpaused",
         "type": "event"
@@ -583,12 +627,12 @@
     {
         "anonymous": false,
         "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "implementation",
-                "type": "address"
-            }
+        {
+            "indexed": true,
+            "internalType": "address",
+            "name": "implementation",
+            "type": "address"
+        }
         ],
         "name": "Upgraded",
         "type": "event"
@@ -596,18 +640,18 @@
     {
         "anonymous": false,
         "inputs": [
-            {
-                "indexed": false,
-                "internalType": "address",
-                "name": "snapshotterAddress",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "bool",
-                "name": "allowed",
-                "type": "bool"
-            }
+        {
+            "indexed": false,
+            "internalType": "address",
+            "name": "snapshotterAddress",
+            "type": "address"
+        },
+        {
+            "indexed": false,
+            "internalType": "bool",
+            "name": "allowed",
+            "type": "bool"
+        }
         ],
         "name": "allSnapshottersUpdated",
         "type": "event"
@@ -616,11 +660,11 @@
         "inputs": [],
         "name": "MAX_SUPPLY",
         "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
@@ -629,32 +673,39 @@
         "inputs": [],
         "name": "UPGRADE_INTERFACE_VERSION",
         "outputs": [
-            {
-                "internalType": "string",
-                "name": "",
-                "type": "string"
-            }
+        {
+            "internalType": "string",
+            "name": "",
+            "type": "string"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
+        "inputs": [],
+        "name": "acceptOwnership",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
         "inputs": [
-            {
-                "internalType": "address",
-                "name": "_to",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_amount",
-                "type": "uint256"
-            },
-            {
-                "internalType": "bool",
-                "name": "_isKyced",
-                "type": "bool"
-            }
+        {
+            "internalType": "address",
+            "name": "_to",
+            "type": "address"
+        },
+        {
+            "internalType": "uint256",
+            "name": "_amount",
+            "type": "uint256"
+        },
+        {
+            "internalType": "bool",
+            "name": "_isKyced",
+            "type": "bool"
+        }
         ],
         "name": "adminMintLegacyNodes",
         "outputs": [],
@@ -663,35 +714,35 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
+        {
+            "internalType": "address",
+            "name": "",
+            "type": "address"
+        }
         ],
         "name": "allSnapshotters",
         "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
+        {
+            "internalType": "bool",
+            "name": "",
+            "type": "bool"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "nodeId",
-                "type": "uint256"
-            },
-            {
-                "internalType": "address",
-                "name": "snapshotterAddress",
-                "type": "address"
-            }
+        {
+            "internalType": "uint256",
+            "name": "nodeId",
+            "type": "uint256"
+        },
+        {
+            "internalType": "address",
+            "name": "snapshotterAddress",
+            "type": "address"
+        }
         ],
         "name": "assignSnapshotterToNode",
         "outputs": [],
@@ -700,16 +751,16 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "nodeId",
-                "type": "uint256"
-            },
-            {
-                "internalType": "address",
-                "name": "snapshotterAddress",
-                "type": "address"
-            }
+        {
+            "internalType": "uint256",
+            "name": "nodeId",
+            "type": "uint256"
+        },
+        {
+            "internalType": "address",
+            "name": "snapshotterAddress",
+            "type": "address"
+        }
         ],
         "name": "assignSnapshotterToNodeAdmin",
         "outputs": [],
@@ -718,16 +769,16 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "uint256[]",
-                "name": "nodeIds",
-                "type": "uint256[]"
-            },
-            {
-                "internalType": "address[]",
-                "name": "snapshotterAddresses",
-                "type": "address[]"
-            }
+        {
+            "internalType": "uint256[]",
+            "name": "nodeIds",
+            "type": "uint256[]"
+        },
+        {
+            "internalType": "address[]",
+            "name": "snapshotterAddresses",
+            "type": "address[]"
+        }
         ],
         "name": "assignSnapshotterToNodeBulk",
         "outputs": [],
@@ -736,16 +787,16 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "uint256[]",
-                "name": "nodeIds",
-                "type": "uint256[]"
-            },
-            {
-                "internalType": "address[]",
-                "name": "snapshotterAddresses",
-                "type": "address[]"
-            }
+        {
+            "internalType": "uint256[]",
+            "name": "nodeIds",
+            "type": "uint256[]"
+        },
+        {
+            "internalType": "address[]",
+            "name": "snapshotterAddresses",
+            "type": "address[]"
+        }
         ],
         "name": "assignSnapshotterToNodeBulkAdmin",
         "outputs": [],
@@ -754,59 +805,59 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "id",
-                "type": "uint256"
-            }
+        {
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+        },
+        {
+            "internalType": "uint256",
+            "name": "id",
+            "type": "uint256"
+        }
         ],
         "name": "balanceOf",
         "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "address[]",
-                "name": "accounts",
-                "type": "address[]"
-            },
-            {
-                "internalType": "uint256[]",
-                "name": "ids",
-                "type": "uint256[]"
-            }
+        {
+            "internalType": "address[]",
+            "name": "accounts",
+            "type": "address[]"
+        },
+        {
+            "internalType": "uint256[]",
+            "name": "ids",
+            "type": "uint256[]"
+        }
         ],
         "name": "balanceOfBatch",
         "outputs": [
-            {
-                "internalType": "uint256[]",
-                "name": "",
-                "type": "uint256[]"
-            }
+        {
+            "internalType": "uint256[]",
+            "name": "",
+            "type": "uint256[]"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "_nodeId",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "_nodeId",
+            "type": "uint256"
+        }
         ],
         "name": "burnNode",
         "outputs": [],
@@ -815,11 +866,11 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "_nodeId",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "_nodeId",
+            "type": "uint256"
+        }
         ],
         "name": "claimNodeTokens",
         "outputs": [],
@@ -828,49 +879,49 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "_nodeId",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "_nodeId",
+            "type": "uint256"
+        }
         ],
         "name": "claimableLegacyNodeTokens",
         "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "_nodeId",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "_nodeId",
+            "type": "uint256"
+        }
         ],
         "name": "claimableNodeTokens",
         "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "_claimableNodeTokens",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "_claimableNodeTokens",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "_nodeId",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "_nodeId",
+            "type": "uint256"
+        }
         ],
         "name": "completeKyc",
         "outputs": [],
@@ -879,57 +930,50 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "_legacyNodeCount",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_legacyNodeInitialClaimPercentage",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_legacyNodeCliff",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_legacyNodeValue",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_legacyNodeVestingDays",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_legacyNodeVestingStart",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_legacyTokensSentOnL1",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_legacyNodeNonKycedCooldown",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "_legacyNodeCount",
+            "type": "uint256"
+        },
+        {
+            "internalType": "uint256",
+            "name": "_legacyNodeInitialClaimPercentage",
+            "type": "uint256"
+        },
+        {
+            "internalType": "uint256",
+            "name": "_legacyNodeCliff",
+            "type": "uint256"
+        },
+        {
+            "internalType": "uint256",
+            "name": "_legacyNodeValue",
+            "type": "uint256"
+        },
+        {
+            "internalType": "uint256",
+            "name": "_legacyNodeVestingDays",
+            "type": "uint256"
+        },
+        {
+            "internalType": "uint256",
+            "name": "_legacyNodeVestingStart",
+            "type": "uint256"
+        },
+        {
+            "internalType": "uint256",
+            "name": "_legacyTokensSentOnL1",
+            "type": "uint256"
+        },
+        {
+            "internalType": "uint256",
+            "name": "_legacyNodeNonKycedCooldown",
+            "type": "uint256"
+        }
         ],
         "name": "configureLegacyNodes",
         "outputs": [],
         "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "deposit",
-        "outputs": [],
-        "stateMutability": "payable",
         "type": "function"
     },
     {
@@ -943,30 +987,30 @@
         "inputs": [],
         "name": "enabledNodeCount",
         "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "id",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "id",
+            "type": "uint256"
+        }
         ],
         "name": "exists",
         "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
+        {
+            "internalType": "bool",
+            "name": "",
+            "type": "bool"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
@@ -975,30 +1019,30 @@
         "inputs": [],
         "name": "getAdmins",
         "outputs": [
-            {
-                "internalType": "address[]",
-                "name": "",
-                "type": "address[]"
-            }
+        {
+            "internalType": "address[]",
+            "name": "",
+            "type": "address[]"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "address",
-                "name": "_address",
-                "type": "address"
-            }
+        {
+            "internalType": "address",
+            "name": "_address",
+            "type": "address"
+        }
         ],
         "name": "getAllUserNodeIds",
         "outputs": [
-            {
-                "internalType": "uint256[]",
-                "name": "",
-                "type": "uint256[]"
-            }
+        {
+            "internalType": "uint256[]",
+            "name": "",
+            "type": "uint256[]"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
@@ -1007,30 +1051,30 @@
         "inputs": [],
         "name": "getLegacyInitialClaim",
         "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "address",
-                "name": "_address",
-                "type": "address"
-            }
+        {
+            "internalType": "address",
+            "name": "_address",
+            "type": "address"
+        }
         ],
         "name": "getNodesOwned",
         "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
@@ -1039,70 +1083,70 @@
         "inputs": [],
         "name": "getTotalSnapshotterCount",
         "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "address",
-                "name": "_address",
-                "type": "address"
-            }
+        {
+            "internalType": "address",
+            "name": "_address",
+            "type": "address"
+        }
         ],
         "name": "getUserBurnedNodeIds",
         "outputs": [
-            {
-                "internalType": "uint256[]",
-                "name": "",
-                "type": "uint256[]"
-            }
+        {
+            "internalType": "uint256[]",
+            "name": "",
+            "type": "uint256[]"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "address",
-                "name": "_address",
-                "type": "address"
-            }
+        {
+            "internalType": "address",
+            "name": "_address",
+            "type": "address"
+        }
         ],
         "name": "getUserOwnedNodeIds",
         "outputs": [
-            {
-                "internalType": "uint256[]",
-                "name": "",
-                "type": "uint256[]"
-            }
+        {
+            "internalType": "uint256[]",
+            "name": "",
+            "type": "uint256[]"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "address",
-                "name": "initialOwner",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "initialNodePrice",
-                "type": "uint256"
-            },
-            {
-                "internalType": "string",
-                "name": "initialName",
-                "type": "string"
-            }
+        {
+            "internalType": "address",
+            "name": "initialOwner",
+            "type": "address"
+        },
+        {
+            "internalType": "uint256",
+            "name": "initialNodePrice",
+            "type": "uint256"
+        },
+        {
+            "internalType": "string",
+            "name": "initialName",
+            "type": "string"
+        }
         ],
         "name": "initialize",
         "outputs": [],
@@ -1111,81 +1155,81 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            },
-            {
-                "internalType": "address",
-                "name": "operator",
-                "type": "address"
-            }
+        {
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+        },
+        {
+            "internalType": "address",
+            "name": "operator",
+            "type": "address"
+        }
         ],
         "name": "isApprovedForAll",
         "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
+        {
+            "internalType": "bool",
+            "name": "",
+            "type": "bool"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "_nodeId",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "_nodeId",
+            "type": "uint256"
+        }
         ],
         "name": "isNodeAvailable",
         "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
+        {
+            "internalType": "bool",
+            "name": "",
+            "type": "bool"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "name": "isNodeBurned",
         "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
+        {
+            "internalType": "bool",
+            "name": "",
+            "type": "bool"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "name": "lastSnapshotterChange",
         "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
@@ -1194,11 +1238,11 @@
         "inputs": [],
         "name": "legacyNodeCliff",
         "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
@@ -1207,11 +1251,11 @@
         "inputs": [],
         "name": "legacyNodeCount",
         "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
@@ -1220,11 +1264,11 @@
         "inputs": [],
         "name": "legacyNodeInitialClaimPercentage",
         "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
@@ -1233,11 +1277,11 @@
         "inputs": [],
         "name": "legacyNodeNonKycedCooldown",
         "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
@@ -1246,11 +1290,11 @@
         "inputs": [],
         "name": "legacyNodeValue",
         "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
@@ -1259,11 +1303,11 @@
         "inputs": [],
         "name": "legacyNodeVestingDays",
         "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
@@ -1272,11 +1316,11 @@
         "inputs": [],
         "name": "legacyNodeVestingStart",
         "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
@@ -1285,22 +1329,22 @@
         "inputs": [],
         "name": "legacyTokensSentOnL1",
         "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+        }
         ],
         "name": "mintNode",
         "outputs": [],
@@ -1311,11 +1355,11 @@
         "inputs": [],
         "name": "mintStartTime",
         "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
@@ -1324,11 +1368,11 @@
         "inputs": [],
         "name": "name",
         "outputs": [
-            {
-                "internalType": "string",
-                "name": "",
-                "type": "string"
-            }
+        {
+            "internalType": "string",
+            "name": "",
+            "type": "string"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
@@ -1337,133 +1381,133 @@
         "inputs": [],
         "name": "nodeCount",
         "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "name": "nodeIdToOwner",
         "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
+        {
+            "internalType": "address",
+            "name": "",
+            "type": "address"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "name": "nodeIdToVestingInfo",
         "outputs": [
-            {
-                "internalType": "address",
-                "name": "owner",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "initialClaim",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "tokensAfterInitialClaim",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "tokensClaimed",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "lastClaim",
-                "type": "uint256"
-            }
+        {
+            "internalType": "address",
+            "name": "owner",
+            "type": "address"
+        },
+        {
+            "internalType": "uint256",
+            "name": "initialClaim",
+            "type": "uint256"
+        },
+        {
+            "internalType": "uint256",
+            "name": "tokensAfterInitialClaim",
+            "type": "uint256"
+        },
+        {
+            "internalType": "uint256",
+            "name": "tokensClaimed",
+            "type": "uint256"
+        },
+        {
+            "internalType": "uint256",
+            "name": "lastClaim",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "name": "nodeInfo",
         "outputs": [
-            {
-                "internalType": "address",
-                "name": "snapshotterAddress",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "nodePrice",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "amountSentOnL1",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "mintedOn",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "burnedOn",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "lastUpdated",
-                "type": "uint256"
-            },
-            {
-                "internalType": "bool",
-                "name": "isLegacy",
-                "type": "bool"
-            },
-            {
-                "internalType": "bool",
-                "name": "claimedTokens",
-                "type": "bool"
-            },
-            {
-                "internalType": "bool",
-                "name": "active",
-                "type": "bool"
-            },
-            {
-                "internalType": "bool",
-                "name": "isKyced",
-                "type": "bool"
-            }
+        {
+            "internalType": "address",
+            "name": "snapshotterAddress",
+            "type": "address"
+        },
+        {
+            "internalType": "uint256",
+            "name": "nodePrice",
+            "type": "uint256"
+        },
+        {
+            "internalType": "uint256",
+            "name": "amountSentOnL1",
+            "type": "uint256"
+        },
+        {
+            "internalType": "uint256",
+            "name": "mintedOn",
+            "type": "uint256"
+        },
+        {
+            "internalType": "uint256",
+            "name": "burnedOn",
+            "type": "uint256"
+        },
+        {
+            "internalType": "uint256",
+            "name": "lastUpdated",
+            "type": "uint256"
+        },
+        {
+            "internalType": "bool",
+            "name": "isLegacy",
+            "type": "bool"
+        },
+        {
+            "internalType": "bool",
+            "name": "claimedTokens",
+            "type": "bool"
+        },
+        {
+            "internalType": "bool",
+            "name": "active",
+            "type": "bool"
+        },
+        {
+            "internalType": "bool",
+            "name": "isKyced",
+            "type": "bool"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
@@ -1472,30 +1516,30 @@
         "inputs": [],
         "name": "nodePrice",
         "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "nodeId",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "nodeId",
+            "type": "uint256"
+        }
         ],
         "name": "nodeSnapshotterMapping",
         "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
+        {
+            "internalType": "address",
+            "name": "",
+            "type": "address"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
@@ -1504,11 +1548,11 @@
         "inputs": [],
         "name": "owner",
         "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
+        {
+            "internalType": "address",
+            "name": "",
+            "type": "address"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
@@ -1524,11 +1568,24 @@
         "inputs": [],
         "name": "paused",
         "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
+        {
+            "internalType": "bool",
+            "name": "",
+            "type": "bool"
+        }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "pendingOwner",
+        "outputs": [
+        {
+            "internalType": "address",
+            "name": "",
+            "type": "address"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
@@ -1537,11 +1594,11 @@
         "inputs": [],
         "name": "proxiableUUID",
         "outputs": [
-            {
-                "internalType": "bytes32",
-                "name": "",
-                "type": "bytes32"
-            }
+        {
+            "internalType": "bytes32",
+            "name": "",
+            "type": "bytes32"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
@@ -1555,31 +1612,31 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            },
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256[]",
-                "name": "",
-                "type": "uint256[]"
-            },
-            {
-                "internalType": "uint256[]",
-                "name": "",
-                "type": "uint256[]"
-            },
-            {
-                "internalType": "bytes",
-                "name": "",
-                "type": "bytes"
-            }
+        {
+            "internalType": "address",
+            "name": "",
+            "type": "address"
+        },
+        {
+            "internalType": "address",
+            "name": "",
+            "type": "address"
+        },
+        {
+            "internalType": "uint256[]",
+            "name": "",
+            "type": "uint256[]"
+        },
+        {
+            "internalType": "uint256[]",
+            "name": "",
+            "type": "uint256[]"
+        },
+        {
+            "internalType": "bytes",
+            "name": "",
+            "type": "bytes"
+        }
         ],
         "name": "safeBatchTransferFrom",
         "outputs": [],
@@ -1588,31 +1645,31 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            },
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            },
-            {
-                "internalType": "bytes",
-                "name": "",
-                "type": "bytes"
-            }
+        {
+            "internalType": "address",
+            "name": "",
+            "type": "address"
+        },
+        {
+            "internalType": "address",
+            "name": "",
+            "type": "address"
+        },
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        },
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        },
+        {
+            "internalType": "bytes",
+            "name": "",
+            "type": "bytes"
+        }
         ],
         "name": "safeTransferFrom",
         "outputs": [],
@@ -1621,16 +1678,16 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "address",
-                "name": "operator",
-                "type": "address"
-            },
-            {
-                "internalType": "bool",
-                "name": "approved",
-                "type": "bool"
-            }
+        {
+            "internalType": "address",
+            "name": "operator",
+            "type": "address"
+        },
+        {
+            "internalType": "bool",
+            "name": "approved",
+            "type": "bool"
+        }
         ],
         "name": "setApprovalForAll",
         "outputs": [],
@@ -1639,11 +1696,11 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "_mintStartTime",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "_mintStartTime",
+            "type": "uint256"
+        }
         ],
         "name": "setMintStartTime",
         "outputs": [],
@@ -1652,11 +1709,11 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "string",
-                "name": "_name",
-                "type": "string"
-            }
+        {
+            "internalType": "string",
+            "name": "_name",
+            "type": "string"
+        }
         ],
         "name": "setName",
         "outputs": [],
@@ -1665,11 +1722,11 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "_snapshotterAddressChangeCooldown",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "_snapshotterAddressChangeCooldown",
+            "type": "uint256"
+        }
         ],
         "name": "setSnapshotterAddressChangeCooldown",
         "outputs": [],
@@ -1678,11 +1735,11 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "_snapshotterTokenClaimCooldown",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "_snapshotterTokenClaimCooldown",
+            "type": "uint256"
+        }
         ],
         "name": "setSnapshotterTokenClaimCooldown",
         "outputs": [],
@@ -1691,11 +1748,11 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "string",
-                "name": "newuri",
-                "type": "string"
-            }
+        {
+            "internalType": "string",
+            "name": "newuri",
+            "type": "string"
+        }
         ],
         "name": "setURI",
         "outputs": [],
@@ -1706,11 +1763,11 @@
         "inputs": [],
         "name": "snapshotterAddressChangeCooldown",
         "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
@@ -1719,30 +1776,30 @@
         "inputs": [],
         "name": "snapshotterTokenClaimCooldown",
         "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "bytes4",
-                "name": "interfaceId",
-                "type": "bytes4"
-            }
+        {
+            "internalType": "bytes4",
+            "name": "interfaceId",
+            "type": "bytes4"
+        }
         ],
         "name": "supportsInterface",
         "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
+        {
+            "internalType": "bool",
+            "name": "",
+            "type": "bool"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
@@ -1751,41 +1808,41 @@
         "inputs": [],
         "name": "totalSupply",
         "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "id",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "id",
+            "type": "uint256"
+        }
         ],
         "name": "totalSupply",
         "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
     },
     {
         "inputs": [
-            {
-                "internalType": "address",
-                "name": "newOwner",
-                "type": "address"
-            }
+        {
+            "internalType": "address",
+            "name": "newOwner",
+            "type": "address"
+        }
         ],
         "name": "transferOwnership",
         "outputs": [],
@@ -1801,16 +1858,16 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "address[]",
-                "name": "_admins",
-                "type": "address[]"
-            },
-            {
-                "internalType": "bool[]",
-                "name": "_status",
-                "type": "bool[]"
-            }
+        {
+            "internalType": "address[]",
+            "name": "_admins",
+            "type": "address[]"
+        },
+        {
+            "internalType": "bool[]",
+            "name": "_status",
+            "type": "bool[]"
+        }
         ],
         "name": "updateAdmins",
         "outputs": [],
@@ -1819,11 +1876,11 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "_maxSupply",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "_maxSupply",
+            "type": "uint256"
+        }
         ],
         "name": "updateMaxSupply",
         "outputs": [],
@@ -1832,11 +1889,11 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "_nodePrice",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "_nodePrice",
+            "type": "uint256"
+        }
         ],
         "name": "updateNodePrice",
         "outputs": [],
@@ -1845,16 +1902,16 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "address",
-                "name": "newImplementation",
-                "type": "address"
-            },
-            {
-                "internalType": "bytes",
-                "name": "data",
-                "type": "bytes"
-            }
+        {
+            "internalType": "address",
+            "name": "newImplementation",
+            "type": "address"
+        },
+        {
+            "internalType": "bytes",
+            "name": "data",
+            "type": "bytes"
+        }
         ],
         "name": "upgradeToAndCall",
         "outputs": [],
@@ -1863,19 +1920,19 @@
     },
     {
         "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "name": "uri",
         "outputs": [
-            {
-                "internalType": "string",
-                "name": "",
-                "type": "string"
-            }
+        {
+            "internalType": "string",
+            "name": "",
+            "type": "string"
+        }
         ],
         "stateMutability": "view",
         "type": "function"
@@ -1884,11 +1941,11 @@
         "inputs": [],
         "name": "vestedLegacyNodeTokens",
         "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
+        {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+        }
         ],
         "stateMutability": "view",
         "type": "function"

--- a/pkgs/snapshotterStateContract/contract.go
+++ b/pkgs/snapshotterStateContract/contract.go
@@ -31,7 +31,7 @@ var (
 
 // SnapshotterStateContractMetaData contains all meta data concerning the SnapshotterStateContract contract.
 var SnapshotterStateContractMetaData = &bind.MetaData{
-	ABI: "[{\"inputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"target\",\"type\":\"address\"}],\"name\":\"AddressEmptyCode\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"balance\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"needed\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"tokenId\",\"type\":\"uint256\"}],\"name\":\"ERC1155InsufficientBalance\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"approver\",\"type\":\"address\"}],\"name\":\"ERC1155InvalidApprover\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"idsLength\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"valuesLength\",\"type\":\"uint256\"}],\"name\":\"ERC1155InvalidArrayLength\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"operator\",\"type\":\"address\"}],\"name\":\"ERC1155InvalidOperator\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"receiver\",\"type\":\"address\"}],\"name\":\"ERC1155InvalidReceiver\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"}],\"name\":\"ERC1155InvalidSender\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"operator\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"ERC1155MissingApprovalForAll\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"implementation\",\"type\":\"address\"}],\"name\":\"ERC1967InvalidImplementation\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"ERC1967NonPayable\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"EnforcedPause\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"ExpectedPause\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"FailedCall\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidInitialization\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"NotInitializing\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"OwnableInvalidOwner\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"OwnableUnauthorizedAccount\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"ReentrancyGuardReentrantCall\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"UUPSUnauthorizedCallContext\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"slot\",\"type\":\"bytes32\"}],\"name\":\"UUPSUnsupportedProxiableUUID\",\"type\":\"error\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"adminAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"bool\",\"name\":\"allowed\",\"type\":\"bool\"}],\"name\":\"AdminsUpdated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"operator\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"bool\",\"name\":\"approved\",\"type\":\"bool\"}],\"name\":\"ApprovalForAll\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"string\",\"name\":\"paramName\",\"type\":\"string\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"newValue\",\"type\":\"uint256\"}],\"name\":\"ConfigurationUpdated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"Deposit\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"EmergencyWithdraw\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"version\",\"type\":\"uint64\"}],\"name\":\"Initialized\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"claimer\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"nodeId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"LegacyNodeTokensClaimed\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"string\",\"name\":\"newName\",\"type\":\"string\"}],\"name\":\"NameUpdated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"nodeId\",\"type\":\"uint256\"}],\"name\":\"NodeBurned\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"nodeId\",\"type\":\"uint256\"}],\"name\":\"NodeMinted\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"previousOwner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"OwnershipTransferred\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"Paused\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"newSnapshotterState\",\"type\":\"address\"}],\"name\":\"SnapshotterStateUpdated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"claimer\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"nodeId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"SnapshotterTokensClaimed\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"operator\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256[]\",\"name\":\"ids\",\"type\":\"uint256[]\"},{\"indexed\":false,\"internalType\":\"uint256[]\",\"name\":\"values\",\"type\":\"uint256[]\"}],\"name\":\"TransferBatch\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"operator\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"id\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"TransferSingle\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"string\",\"name\":\"value\",\"type\":\"string\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"id\",\"type\":\"uint256\"}],\"name\":\"URI\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"string\",\"name\":\"newUri\",\"type\":\"string\"}],\"name\":\"URIUpdated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"Unpaused\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"implementation\",\"type\":\"address\"}],\"name\":\"Upgraded\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"snapshotterAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"bool\",\"name\":\"allowed\",\"type\":\"bool\"}],\"name\":\"allSnapshottersUpdated\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"MAX_SUPPLY\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"UPGRADE_INTERFACE_VERSION\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"_amount\",\"type\":\"uint256\"},{\"internalType\":\"bool\",\"name\":\"_isKyced\",\"type\":\"bool\"}],\"name\":\"adminMintLegacyNodes\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"name\":\"allSnapshotters\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeId\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"snapshotterAddress\",\"type\":\"address\"}],\"name\":\"assignSnapshotterToNode\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeId\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"snapshotterAddress\",\"type\":\"address\"}],\"name\":\"assignSnapshotterToNodeAdmin\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256[]\",\"name\":\"nodeIds\",\"type\":\"uint256[]\"},{\"internalType\":\"address[]\",\"name\":\"snapshotterAddresses\",\"type\":\"address[]\"}],\"name\":\"assignSnapshotterToNodeBulk\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256[]\",\"name\":\"nodeIds\",\"type\":\"uint256[]\"},{\"internalType\":\"address[]\",\"name\":\"snapshotterAddresses\",\"type\":\"address[]\"}],\"name\":\"assignSnapshotterToNodeBulkAdmin\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"id\",\"type\":\"uint256\"}],\"name\":\"balanceOf\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address[]\",\"name\":\"accounts\",\"type\":\"address[]\"},{\"internalType\":\"uint256[]\",\"name\":\"ids\",\"type\":\"uint256[]\"}],\"name\":\"balanceOfBatch\",\"outputs\":[{\"internalType\":\"uint256[]\",\"name\":\"\",\"type\":\"uint256[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"_nodeId\",\"type\":\"uint256\"}],\"name\":\"burnNode\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"_nodeId\",\"type\":\"uint256\"}],\"name\":\"claimNodeTokens\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"_nodeId\",\"type\":\"uint256\"}],\"name\":\"claimableLegacyNodeTokens\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"_nodeId\",\"type\":\"uint256\"}],\"name\":\"claimableNodeTokens\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"_claimableNodeTokens\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"_nodeId\",\"type\":\"uint256\"}],\"name\":\"completeKyc\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"_legacyNodeCount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"_legacyNodeInitialClaimPercentage\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"_legacyNodeCliff\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"_legacyNodeValue\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"_legacyNodeVestingDays\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"_legacyNodeVestingStart\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"_legacyTokensSentOnL1\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"_legacyNodeNonKycedCooldown\",\"type\":\"uint256\"}],\"name\":\"configureLegacyNodes\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"deposit\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"emergencyWithdraw\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"enabledNodeCount\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"id\",\"type\":\"uint256\"}],\"name\":\"exists\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getAdmins\",\"outputs\":[{\"internalType\":\"address[]\",\"name\":\"\",\"type\":\"address[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_address\",\"type\":\"address\"}],\"name\":\"getAllUserNodeIds\",\"outputs\":[{\"internalType\":\"uint256[]\",\"name\":\"\",\"type\":\"uint256[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getLegacyInitialClaim\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_address\",\"type\":\"address\"}],\"name\":\"getNodesOwned\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getTotalSnapshotterCount\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_address\",\"type\":\"address\"}],\"name\":\"getUserBurnedNodeIds\",\"outputs\":[{\"internalType\":\"uint256[]\",\"name\":\"\",\"type\":\"uint256[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_address\",\"type\":\"address\"}],\"name\":\"getUserOwnedNodeIds\",\"outputs\":[{\"internalType\":\"uint256[]\",\"name\":\"\",\"type\":\"uint256[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"initialOwner\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"initialNodePrice\",\"type\":\"uint256\"},{\"internalType\":\"string\",\"name\":\"initialName\",\"type\":\"string\"}],\"name\":\"initialize\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"operator\",\"type\":\"address\"}],\"name\":\"isApprovedForAll\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"_nodeId\",\"type\":\"uint256\"}],\"name\":\"isNodeAvailable\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"isNodeBurned\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"lastSnapshotterChange\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"legacyNodeCliff\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"legacyNodeCount\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"legacyNodeInitialClaimPercentage\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"legacyNodeNonKycedCooldown\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"legacyNodeValue\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"legacyNodeVestingDays\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"legacyNodeVestingStart\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"legacyTokensSentOnL1\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"mintNode\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"mintStartTime\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"name\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"nodeCount\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"nodeIdToOwner\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"nodeIdToVestingInfo\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"initialClaim\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"tokensAfterInitialClaim\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"tokensClaimed\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"lastClaim\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"nodeInfo\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"snapshotterAddress\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"nodePrice\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountSentOnL1\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"mintedOn\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"burnedOn\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"lastUpdated\",\"type\":\"uint256\"},{\"internalType\":\"bool\",\"name\":\"isLegacy\",\"type\":\"bool\"},{\"internalType\":\"bool\",\"name\":\"claimedTokens\",\"type\":\"bool\"},{\"internalType\":\"bool\",\"name\":\"active\",\"type\":\"bool\"},{\"internalType\":\"bool\",\"name\":\"isKyced\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"nodePrice\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeId\",\"type\":\"uint256\"}],\"name\":\"nodeSnapshotterMapping\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"pause\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"paused\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"proxiableUUID\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"renounceOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"},{\"internalType\":\"uint256[]\",\"name\":\"\",\"type\":\"uint256[]\"},{\"internalType\":\"uint256[]\",\"name\":\"\",\"type\":\"uint256[]\"},{\"internalType\":\"bytes\",\"name\":\"\",\"type\":\"bytes\"}],\"name\":\"safeBatchTransferFrom\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"\",\"type\":\"bytes\"}],\"name\":\"safeTransferFrom\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"operator\",\"type\":\"address\"},{\"internalType\":\"bool\",\"name\":\"approved\",\"type\":\"bool\"}],\"name\":\"setApprovalForAll\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"_mintStartTime\",\"type\":\"uint256\"}],\"name\":\"setMintStartTime\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"_name\",\"type\":\"string\"}],\"name\":\"setName\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"_snapshotterAddressChangeCooldown\",\"type\":\"uint256\"}],\"name\":\"setSnapshotterAddressChangeCooldown\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"_snapshotterTokenClaimCooldown\",\"type\":\"uint256\"}],\"name\":\"setSnapshotterTokenClaimCooldown\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"newuri\",\"type\":\"string\"}],\"name\":\"setURI\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"snapshotterAddressChangeCooldown\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"snapshotterTokenClaimCooldown\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes4\",\"name\":\"interfaceId\",\"type\":\"bytes4\"}],\"name\":\"supportsInterface\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"totalSupply\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"id\",\"type\":\"uint256\"}],\"name\":\"totalSupply\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"transferOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"unpause\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address[]\",\"name\":\"_admins\",\"type\":\"address[]\"},{\"internalType\":\"bool[]\",\"name\":\"_status\",\"type\":\"bool[]\"}],\"name\":\"updateAdmins\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"_maxSupply\",\"type\":\"uint256\"}],\"name\":\"updateMaxSupply\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"_nodePrice\",\"type\":\"uint256\"}],\"name\":\"updateNodePrice\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newImplementation\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"}],\"name\":\"upgradeToAndCall\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"uri\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"vestedLegacyNodeTokens\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"stateMutability\":\"payable\",\"type\":\"receive\"}]",
+	ABI: "[{\"inputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"target\",\"type\":\"address\"}],\"name\":\"AddressEmptyCode\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"balance\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"needed\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"tokenId\",\"type\":\"uint256\"}],\"name\":\"ERC1155InsufficientBalance\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"approver\",\"type\":\"address\"}],\"name\":\"ERC1155InvalidApprover\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"idsLength\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"valuesLength\",\"type\":\"uint256\"}],\"name\":\"ERC1155InvalidArrayLength\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"operator\",\"type\":\"address\"}],\"name\":\"ERC1155InvalidOperator\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"receiver\",\"type\":\"address\"}],\"name\":\"ERC1155InvalidReceiver\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"}],\"name\":\"ERC1155InvalidSender\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"operator\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"ERC1155MissingApprovalForAll\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"implementation\",\"type\":\"address\"}],\"name\":\"ERC1967InvalidImplementation\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"ERC1967NonPayable\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"EnforcedPause\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"ExpectedPause\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"FailedCall\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidInitialization\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"NotInitializing\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"OwnableInvalidOwner\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"OwnableUnauthorizedAccount\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"ReentrancyGuardReentrantCall\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"UUPSUnauthorizedCallContext\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"slot\",\"type\":\"bytes32\"}],\"name\":\"UUPSUnsupportedProxiableUUID\",\"type\":\"error\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"adminAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"bool\",\"name\":\"allowed\",\"type\":\"bool\"}],\"name\":\"AdminsUpdated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"operator\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"bool\",\"name\":\"approved\",\"type\":\"bool\"}],\"name\":\"ApprovalForAll\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"string\",\"name\":\"paramName\",\"type\":\"string\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"newValue\",\"type\":\"uint256\"}],\"name\":\"ConfigurationUpdated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"Deposit\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"EmergencyWithdraw\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"version\",\"type\":\"uint64\"}],\"name\":\"Initialized\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"claimer\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"nodeId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"LegacyNodeTokensClaimed\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"string\",\"name\":\"newName\",\"type\":\"string\"}],\"name\":\"NameUpdated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"nodeId\",\"type\":\"uint256\"}],\"name\":\"NodeBurned\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"nodeId\",\"type\":\"uint256\"}],\"name\":\"NodeMinted\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"previousOwner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"OwnershipTransferStarted\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"previousOwner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"OwnershipTransferred\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"Paused\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"nodeId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"oldSnapshotter\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"newSnapshotter\",\"type\":\"address\"}],\"name\":\"SnapshotterAddressChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"newSnapshotterState\",\"type\":\"address\"}],\"name\":\"SnapshotterStateUpdated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"claimer\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"nodeId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"SnapshotterTokensClaimed\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"operator\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256[]\",\"name\":\"ids\",\"type\":\"uint256[]\"},{\"indexed\":false,\"internalType\":\"uint256[]\",\"name\":\"values\",\"type\":\"uint256[]\"}],\"name\":\"TransferBatch\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"operator\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"id\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"TransferSingle\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"string\",\"name\":\"value\",\"type\":\"string\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"id\",\"type\":\"uint256\"}],\"name\":\"URI\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"string\",\"name\":\"newUri\",\"type\":\"string\"}],\"name\":\"URIUpdated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"Unpaused\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"implementation\",\"type\":\"address\"}],\"name\":\"Upgraded\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"snapshotterAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"bool\",\"name\":\"allowed\",\"type\":\"bool\"}],\"name\":\"allSnapshottersUpdated\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"MAX_SUPPLY\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"UPGRADE_INTERFACE_VERSION\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"acceptOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"_amount\",\"type\":\"uint256\"},{\"internalType\":\"bool\",\"name\":\"_isKyced\",\"type\":\"bool\"}],\"name\":\"adminMintLegacyNodes\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"name\":\"allSnapshotters\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeId\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"snapshotterAddress\",\"type\":\"address\"}],\"name\":\"assignSnapshotterToNode\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeId\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"snapshotterAddress\",\"type\":\"address\"}],\"name\":\"assignSnapshotterToNodeAdmin\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256[]\",\"name\":\"nodeIds\",\"type\":\"uint256[]\"},{\"internalType\":\"address[]\",\"name\":\"snapshotterAddresses\",\"type\":\"address[]\"}],\"name\":\"assignSnapshotterToNodeBulk\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256[]\",\"name\":\"nodeIds\",\"type\":\"uint256[]\"},{\"internalType\":\"address[]\",\"name\":\"snapshotterAddresses\",\"type\":\"address[]\"}],\"name\":\"assignSnapshotterToNodeBulkAdmin\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"id\",\"type\":\"uint256\"}],\"name\":\"balanceOf\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address[]\",\"name\":\"accounts\",\"type\":\"address[]\"},{\"internalType\":\"uint256[]\",\"name\":\"ids\",\"type\":\"uint256[]\"}],\"name\":\"balanceOfBatch\",\"outputs\":[{\"internalType\":\"uint256[]\",\"name\":\"\",\"type\":\"uint256[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"_nodeId\",\"type\":\"uint256\"}],\"name\":\"burnNode\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"_nodeId\",\"type\":\"uint256\"}],\"name\":\"claimNodeTokens\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"_nodeId\",\"type\":\"uint256\"}],\"name\":\"claimableLegacyNodeTokens\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"_nodeId\",\"type\":\"uint256\"}],\"name\":\"claimableNodeTokens\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"_claimableNodeTokens\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"_nodeId\",\"type\":\"uint256\"}],\"name\":\"completeKyc\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"_legacyNodeCount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"_legacyNodeInitialClaimPercentage\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"_legacyNodeCliff\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"_legacyNodeValue\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"_legacyNodeVestingDays\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"_legacyNodeVestingStart\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"_legacyTokensSentOnL1\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"_legacyNodeNonKycedCooldown\",\"type\":\"uint256\"}],\"name\":\"configureLegacyNodes\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"emergencyWithdraw\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"enabledNodeCount\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"id\",\"type\":\"uint256\"}],\"name\":\"exists\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getAdmins\",\"outputs\":[{\"internalType\":\"address[]\",\"name\":\"\",\"type\":\"address[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_address\",\"type\":\"address\"}],\"name\":\"getAllUserNodeIds\",\"outputs\":[{\"internalType\":\"uint256[]\",\"name\":\"\",\"type\":\"uint256[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getLegacyInitialClaim\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_address\",\"type\":\"address\"}],\"name\":\"getNodesOwned\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getTotalSnapshotterCount\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_address\",\"type\":\"address\"}],\"name\":\"getUserBurnedNodeIds\",\"outputs\":[{\"internalType\":\"uint256[]\",\"name\":\"\",\"type\":\"uint256[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_address\",\"type\":\"address\"}],\"name\":\"getUserOwnedNodeIds\",\"outputs\":[{\"internalType\":\"uint256[]\",\"name\":\"\",\"type\":\"uint256[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"initialOwner\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"initialNodePrice\",\"type\":\"uint256\"},{\"internalType\":\"string\",\"name\":\"initialName\",\"type\":\"string\"}],\"name\":\"initialize\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"operator\",\"type\":\"address\"}],\"name\":\"isApprovedForAll\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"_nodeId\",\"type\":\"uint256\"}],\"name\":\"isNodeAvailable\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"isNodeBurned\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"lastSnapshotterChange\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"legacyNodeCliff\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"legacyNodeCount\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"legacyNodeInitialClaimPercentage\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"legacyNodeNonKycedCooldown\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"legacyNodeValue\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"legacyNodeVestingDays\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"legacyNodeVestingStart\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"legacyTokensSentOnL1\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"mintNode\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"mintStartTime\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"name\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"nodeCount\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"nodeIdToOwner\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"nodeIdToVestingInfo\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"initialClaim\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"tokensAfterInitialClaim\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"tokensClaimed\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"lastClaim\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"nodeInfo\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"snapshotterAddress\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"nodePrice\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountSentOnL1\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"mintedOn\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"burnedOn\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"lastUpdated\",\"type\":\"uint256\"},{\"internalType\":\"bool\",\"name\":\"isLegacy\",\"type\":\"bool\"},{\"internalType\":\"bool\",\"name\":\"claimedTokens\",\"type\":\"bool\"},{\"internalType\":\"bool\",\"name\":\"active\",\"type\":\"bool\"},{\"internalType\":\"bool\",\"name\":\"isKyced\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"nodePrice\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nodeId\",\"type\":\"uint256\"}],\"name\":\"nodeSnapshotterMapping\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"pause\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"paused\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"pendingOwner\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"proxiableUUID\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"renounceOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"},{\"internalType\":\"uint256[]\",\"name\":\"\",\"type\":\"uint256[]\"},{\"internalType\":\"uint256[]\",\"name\":\"\",\"type\":\"uint256[]\"},{\"internalType\":\"bytes\",\"name\":\"\",\"type\":\"bytes\"}],\"name\":\"safeBatchTransferFrom\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"\",\"type\":\"bytes\"}],\"name\":\"safeTransferFrom\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"operator\",\"type\":\"address\"},{\"internalType\":\"bool\",\"name\":\"approved\",\"type\":\"bool\"}],\"name\":\"setApprovalForAll\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"_mintStartTime\",\"type\":\"uint256\"}],\"name\":\"setMintStartTime\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"_name\",\"type\":\"string\"}],\"name\":\"setName\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"_snapshotterAddressChangeCooldown\",\"type\":\"uint256\"}],\"name\":\"setSnapshotterAddressChangeCooldown\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"_snapshotterTokenClaimCooldown\",\"type\":\"uint256\"}],\"name\":\"setSnapshotterTokenClaimCooldown\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"newuri\",\"type\":\"string\"}],\"name\":\"setURI\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"snapshotterAddressChangeCooldown\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"snapshotterTokenClaimCooldown\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes4\",\"name\":\"interfaceId\",\"type\":\"bytes4\"}],\"name\":\"supportsInterface\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"totalSupply\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"id\",\"type\":\"uint256\"}],\"name\":\"totalSupply\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"transferOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"unpause\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address[]\",\"name\":\"_admins\",\"type\":\"address[]\"},{\"internalType\":\"bool[]\",\"name\":\"_status\",\"type\":\"bool[]\"}],\"name\":\"updateAdmins\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"_maxSupply\",\"type\":\"uint256\"}],\"name\":\"updateMaxSupply\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"_nodePrice\",\"type\":\"uint256\"}],\"name\":\"updateNodePrice\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newImplementation\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"}],\"name\":\"upgradeToAndCall\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"uri\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"vestedLegacyNodeTokens\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"stateMutability\":\"payable\",\"type\":\"receive\"}]",
 }
 
 // SnapshotterStateContractABI is the input ABI used to generate the binding from.
@@ -1441,6 +1441,37 @@ func (_SnapshotterStateContract *SnapshotterStateContractCallerSession) Paused()
 	return _SnapshotterStateContract.Contract.Paused(&_SnapshotterStateContract.CallOpts)
 }
 
+// PendingOwner is a free data retrieval call binding the contract method 0xe30c3978.
+//
+// Solidity: function pendingOwner() view returns(address)
+func (_SnapshotterStateContract *SnapshotterStateContractCaller) PendingOwner(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _SnapshotterStateContract.contract.Call(opts, &out, "pendingOwner")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// PendingOwner is a free data retrieval call binding the contract method 0xe30c3978.
+//
+// Solidity: function pendingOwner() view returns(address)
+func (_SnapshotterStateContract *SnapshotterStateContractSession) PendingOwner() (common.Address, error) {
+	return _SnapshotterStateContract.Contract.PendingOwner(&_SnapshotterStateContract.CallOpts)
+}
+
+// PendingOwner is a free data retrieval call binding the contract method 0xe30c3978.
+//
+// Solidity: function pendingOwner() view returns(address)
+func (_SnapshotterStateContract *SnapshotterStateContractCallerSession) PendingOwner() (common.Address, error) {
+	return _SnapshotterStateContract.Contract.PendingOwner(&_SnapshotterStateContract.CallOpts)
+}
+
 // ProxiableUUID is a free data retrieval call binding the contract method 0x52d1902d.
 //
 // Solidity: function proxiableUUID() view returns(bytes32)
@@ -1689,6 +1720,27 @@ func (_SnapshotterStateContract *SnapshotterStateContractCallerSession) VestedLe
 	return _SnapshotterStateContract.Contract.VestedLegacyNodeTokens(&_SnapshotterStateContract.CallOpts)
 }
 
+// AcceptOwnership is a paid mutator transaction binding the contract method 0x79ba5097.
+//
+// Solidity: function acceptOwnership() returns()
+func (_SnapshotterStateContract *SnapshotterStateContractTransactor) AcceptOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _SnapshotterStateContract.contract.Transact(opts, "acceptOwnership")
+}
+
+// AcceptOwnership is a paid mutator transaction binding the contract method 0x79ba5097.
+//
+// Solidity: function acceptOwnership() returns()
+func (_SnapshotterStateContract *SnapshotterStateContractSession) AcceptOwnership() (*types.Transaction, error) {
+	return _SnapshotterStateContract.Contract.AcceptOwnership(&_SnapshotterStateContract.TransactOpts)
+}
+
+// AcceptOwnership is a paid mutator transaction binding the contract method 0x79ba5097.
+//
+// Solidity: function acceptOwnership() returns()
+func (_SnapshotterStateContract *SnapshotterStateContractTransactorSession) AcceptOwnership() (*types.Transaction, error) {
+	return _SnapshotterStateContract.Contract.AcceptOwnership(&_SnapshotterStateContract.TransactOpts)
+}
+
 // AdminMintLegacyNodes is a paid mutator transaction binding the contract method 0x0e4376bb.
 //
 // Solidity: function adminMintLegacyNodes(address _to, uint256 _amount, bool _isKyced) returns()
@@ -1876,27 +1928,6 @@ func (_SnapshotterStateContract *SnapshotterStateContractSession) ConfigureLegac
 // Solidity: function configureLegacyNodes(uint256 _legacyNodeCount, uint256 _legacyNodeInitialClaimPercentage, uint256 _legacyNodeCliff, uint256 _legacyNodeValue, uint256 _legacyNodeVestingDays, uint256 _legacyNodeVestingStart, uint256 _legacyTokensSentOnL1, uint256 _legacyNodeNonKycedCooldown) returns()
 func (_SnapshotterStateContract *SnapshotterStateContractTransactorSession) ConfigureLegacyNodes(_legacyNodeCount *big.Int, _legacyNodeInitialClaimPercentage *big.Int, _legacyNodeCliff *big.Int, _legacyNodeValue *big.Int, _legacyNodeVestingDays *big.Int, _legacyNodeVestingStart *big.Int, _legacyTokensSentOnL1 *big.Int, _legacyNodeNonKycedCooldown *big.Int) (*types.Transaction, error) {
 	return _SnapshotterStateContract.Contract.ConfigureLegacyNodes(&_SnapshotterStateContract.TransactOpts, _legacyNodeCount, _legacyNodeInitialClaimPercentage, _legacyNodeCliff, _legacyNodeValue, _legacyNodeVestingDays, _legacyNodeVestingStart, _legacyTokensSentOnL1, _legacyNodeNonKycedCooldown)
-}
-
-// Deposit is a paid mutator transaction binding the contract method 0xd0e30db0.
-//
-// Solidity: function deposit() payable returns()
-func (_SnapshotterStateContract *SnapshotterStateContractTransactor) Deposit(opts *bind.TransactOpts) (*types.Transaction, error) {
-	return _SnapshotterStateContract.contract.Transact(opts, "deposit")
-}
-
-// Deposit is a paid mutator transaction binding the contract method 0xd0e30db0.
-//
-// Solidity: function deposit() payable returns()
-func (_SnapshotterStateContract *SnapshotterStateContractSession) Deposit() (*types.Transaction, error) {
-	return _SnapshotterStateContract.Contract.Deposit(&_SnapshotterStateContract.TransactOpts)
-}
-
-// Deposit is a paid mutator transaction binding the contract method 0xd0e30db0.
-//
-// Solidity: function deposit() payable returns()
-func (_SnapshotterStateContract *SnapshotterStateContractTransactorSession) Deposit() (*types.Transaction, error) {
-	return _SnapshotterStateContract.Contract.Deposit(&_SnapshotterStateContract.TransactOpts)
 }
 
 // EmergencyWithdraw is a paid mutator transaction binding the contract method 0xdb2e21bc.
@@ -3737,6 +3768,159 @@ func (_SnapshotterStateContract *SnapshotterStateContractFilterer) ParseNodeMint
 	return event, nil
 }
 
+// SnapshotterStateContractOwnershipTransferStartedIterator is returned from FilterOwnershipTransferStarted and is used to iterate over the raw logs and unpacked data for OwnershipTransferStarted events raised by the SnapshotterStateContract contract.
+type SnapshotterStateContractOwnershipTransferStartedIterator struct {
+	Event *SnapshotterStateContractOwnershipTransferStarted // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *SnapshotterStateContractOwnershipTransferStartedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(SnapshotterStateContractOwnershipTransferStarted)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(SnapshotterStateContractOwnershipTransferStarted)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *SnapshotterStateContractOwnershipTransferStartedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *SnapshotterStateContractOwnershipTransferStartedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// SnapshotterStateContractOwnershipTransferStarted represents a OwnershipTransferStarted event raised by the SnapshotterStateContract contract.
+type SnapshotterStateContractOwnershipTransferStarted struct {
+	PreviousOwner common.Address
+	NewOwner      common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnershipTransferStarted is a free log retrieval operation binding the contract event 0x38d16b8cac22d99fc7c124b9cd0de2d3fa1faef420bfe791d8c362d765e22700.
+//
+// Solidity: event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
+func (_SnapshotterStateContract *SnapshotterStateContractFilterer) FilterOwnershipTransferStarted(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*SnapshotterStateContractOwnershipTransferStartedIterator, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _SnapshotterStateContract.contract.FilterLogs(opts, "OwnershipTransferStarted", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &SnapshotterStateContractOwnershipTransferStartedIterator{contract: _SnapshotterStateContract.contract, event: "OwnershipTransferStarted", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnershipTransferStarted is a free log subscription operation binding the contract event 0x38d16b8cac22d99fc7c124b9cd0de2d3fa1faef420bfe791d8c362d765e22700.
+//
+// Solidity: event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
+func (_SnapshotterStateContract *SnapshotterStateContractFilterer) WatchOwnershipTransferStarted(opts *bind.WatchOpts, sink chan<- *SnapshotterStateContractOwnershipTransferStarted, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _SnapshotterStateContract.contract.WatchLogs(opts, "OwnershipTransferStarted", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(SnapshotterStateContractOwnershipTransferStarted)
+				if err := _SnapshotterStateContract.contract.UnpackLog(event, "OwnershipTransferStarted", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOwnershipTransferStarted is a log parse operation binding the contract event 0x38d16b8cac22d99fc7c124b9cd0de2d3fa1faef420bfe791d8c362d765e22700.
+//
+// Solidity: event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)
+func (_SnapshotterStateContract *SnapshotterStateContractFilterer) ParseOwnershipTransferStarted(log types.Log) (*SnapshotterStateContractOwnershipTransferStarted, error) {
+	event := new(SnapshotterStateContractOwnershipTransferStarted)
+	if err := _SnapshotterStateContract.contract.UnpackLog(event, "OwnershipTransferStarted", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
 // SnapshotterStateContractOwnershipTransferredIterator is returned from FilterOwnershipTransferred and is used to iterate over the raw logs and unpacked data for OwnershipTransferred events raised by the SnapshotterStateContract contract.
 type SnapshotterStateContractOwnershipTransferredIterator struct {
 	Event *SnapshotterStateContractOwnershipTransferred // Event containing the contract specifics and raw log
@@ -4018,6 +4202,142 @@ func (_SnapshotterStateContract *SnapshotterStateContractFilterer) WatchPaused(o
 func (_SnapshotterStateContract *SnapshotterStateContractFilterer) ParsePaused(log types.Log) (*SnapshotterStateContractPaused, error) {
 	event := new(SnapshotterStateContractPaused)
 	if err := _SnapshotterStateContract.contract.UnpackLog(event, "Paused", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// SnapshotterStateContractSnapshotterAddressChangedIterator is returned from FilterSnapshotterAddressChanged and is used to iterate over the raw logs and unpacked data for SnapshotterAddressChanged events raised by the SnapshotterStateContract contract.
+type SnapshotterStateContractSnapshotterAddressChangedIterator struct {
+	Event *SnapshotterStateContractSnapshotterAddressChanged // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *SnapshotterStateContractSnapshotterAddressChangedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(SnapshotterStateContractSnapshotterAddressChanged)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(SnapshotterStateContractSnapshotterAddressChanged)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *SnapshotterStateContractSnapshotterAddressChangedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *SnapshotterStateContractSnapshotterAddressChangedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// SnapshotterStateContractSnapshotterAddressChanged represents a SnapshotterAddressChanged event raised by the SnapshotterStateContract contract.
+type SnapshotterStateContractSnapshotterAddressChanged struct {
+	NodeId         *big.Int
+	OldSnapshotter common.Address
+	NewSnapshotter common.Address
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterSnapshotterAddressChanged is a free log retrieval operation binding the contract event 0xf144ab1c632c4ddc8e89ce0dc5d941b4a7d76cc4a8b5f3189deeee0c23071c39.
+//
+// Solidity: event SnapshotterAddressChanged(uint256 nodeId, address oldSnapshotter, address newSnapshotter)
+func (_SnapshotterStateContract *SnapshotterStateContractFilterer) FilterSnapshotterAddressChanged(opts *bind.FilterOpts) (*SnapshotterStateContractSnapshotterAddressChangedIterator, error) {
+
+	logs, sub, err := _SnapshotterStateContract.contract.FilterLogs(opts, "SnapshotterAddressChanged")
+	if err != nil {
+		return nil, err
+	}
+	return &SnapshotterStateContractSnapshotterAddressChangedIterator{contract: _SnapshotterStateContract.contract, event: "SnapshotterAddressChanged", logs: logs, sub: sub}, nil
+}
+
+// WatchSnapshotterAddressChanged is a free log subscription operation binding the contract event 0xf144ab1c632c4ddc8e89ce0dc5d941b4a7d76cc4a8b5f3189deeee0c23071c39.
+//
+// Solidity: event SnapshotterAddressChanged(uint256 nodeId, address oldSnapshotter, address newSnapshotter)
+func (_SnapshotterStateContract *SnapshotterStateContractFilterer) WatchSnapshotterAddressChanged(opts *bind.WatchOpts, sink chan<- *SnapshotterStateContractSnapshotterAddressChanged) (event.Subscription, error) {
+
+	logs, sub, err := _SnapshotterStateContract.contract.WatchLogs(opts, "SnapshotterAddressChanged")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(SnapshotterStateContractSnapshotterAddressChanged)
+				if err := _SnapshotterStateContract.contract.UnpackLog(event, "SnapshotterAddressChanged", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseSnapshotterAddressChanged is a log parse operation binding the contract event 0xf144ab1c632c4ddc8e89ce0dc5d941b4a7d76cc4a8b5f3189deeee0c23071c39.
+//
+// Solidity: event SnapshotterAddressChanged(uint256 nodeId, address oldSnapshotter, address newSnapshotter)
+func (_SnapshotterStateContract *SnapshotterStateContractFilterer) ParseSnapshotterAddressChanged(log types.Log) (*SnapshotterStateContractSnapshotterAddressChanged, error) {
+	event := new(SnapshotterStateContractSnapshotterAddressChanged)
+	if err := _SnapshotterStateContract.contract.UnpackLog(event, "SnapshotterAddressChanged", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log


### PR DESCRIPTION
<!-- Please create (if there is not one yet) a issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->
<!-- Always provide changes in existing tests or new tests -->

Fixes #7

### Checklist
- [x] My branch is up-to-date with upstream/main branch.
- [x] Everything works and tested for major version of Python/NodeJS/Go and above.
- [x] I ran pre-commit checks against my changes.
- [x] I've written tests against my changes and all the current present tests are passing.

### Current behaviour
The cacher currently collects and stores the data for each snapshotter slot id by making a call to the Protocol State contract for each slot and for each data market that the cacher is monitoring. This is unnecessary as the slot data does not change across data markets belonging to the same Protocol State contract, only across different Snapshotter State contracts. This leaves the cacher making many unneeded calls.

### New expected behaviour
The cacher will now collect the slot id data from the snapshotter state contract only once on startup, and then again for each slot on the set period. The contract ABIs have also been brought up to the latest mainnet version of the contracts.

### Change logs

<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->


#### Changed

1. `pkgs/contract/abi.json`
   - Updated ABI definitions to match new contract version

2. `pkgs/contract/snapshotterStateContract.go`
   - Updated contract bindings
   - Removed deprecated methods (PendingOwner, AcceptOwnership)
   - Removed deprecated events (OwnershipTransferStarted, SnapshotterAddressChanged)
   - Added new Deposit method

3. `pkgs/prost/contract.go`
   - Refactored slot data collection to use snapshotterStateContract directly
   - Updated FetchAllSlots() to not iterate over data markets
   - Updated addSlotInfo() to work with snapshotterStateContract directly

4. `pkgs/prost/processor.go`
   - Updated ProcessSnapshotterStateEvents() to only pass slot id to addSlotInfo
   - Modified addSlotInfo() to work with new contract interface

5. `pkgs/snapshotterStateContract/abi.json`
   - Updated ABI definitions to match new contract version

<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->

## Deployment Instructions
No changes
