### PR TITLE
chore: remove misleading logs about flushing of batches

### DIFF
--- a/pkgs/prost/processor.go
+++ b/pkgs/prost/processor.go
@@ -253,7 +253,7 @@ func (sm *SlotManager) flushSlots() {
 	}
 	allSlotsKey := redis.AllSlotInfo()
 	redis.RedisClient.SAdd(context.Background(), allSlotsKey, slots...)
-	log.Printf("Flushed batch of %d slots to Redis. Range: %v - %v", len(sm.slots), slots[0], slots[len(slots)-1])
+	log.Printf("Flushed batch of %d slots to Redis", len(sm.slots))
 	sm.slots = make(map[int64]string)
 }
 


### PR DESCRIPTION

<!-- Please create (if there is not one yet) a issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->
<!-- Always provide changes in existing tests or new tests -->

### Fixes:

Read section on current behavior below

### Checklist
- [x] My branch is up-to-date with upstream/main branch.
- [x] Everything works and tested for major version of Python/NodeJS/Go and above.
- [x] I ran pre-commit checks against my changes.
- [x] I've written tests against my changes and all the current present tests are passing.

### Current behaviour

The SlotManager's flushSlots method logs misleading information about the range of slots being flushed to Redis. The log message "Flushed batch of X slots to Redis. Range: Y - Z" shows random values for Y and Z that don't accurately represent the actual range of slot IDs, causing confusion during monitoring and debugging.

### New expected behaviour
The log message is simplified to only show the count of slots being flushed, removing the misleading range information. This provides clear and accurate information about batch operations without adding unnecessary overhead.

### Change logs

#### Changed
- Simplified log message in SlotManager.flushSlots to only show the count of slots being flushed
- Removed misleading range information from log output

#### Fixed
- Fixed misleading log messages that showed incorrect slot ID ranges during batch operations

## Deployment Instructions
<!-- Any specific deployment instructions to deploy your code -->
